### PR TITLE
bump til nyeste notifikasjon-widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@craco/craco": "^6.4.3",
-        "@navikt/arbeidsgiver-notifikasjon-widget": "2.0.2",
+        "@navikt/arbeidsgiver-notifikasjon-widget": "2.0.3",
         "@navikt/bedriftsmeny": "3.5.3",
         "@navikt/ds-css": "^0.14.1",
         "@navikt/ds-icons": "^0.7.2",
@@ -2835,9 +2835,9 @@
       }
     },
     "node_modules/@navikt/arbeidsgiver-notifikasjon-widget": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@navikt/arbeidsgiver-notifikasjon-widget/-/arbeidsgiver-notifikasjon-widget-2.0.2.tgz",
-      "integrity": "sha512-3UVc6iJlK45n9IssfmsjOUttOUfLQoa137xduEsL6obWC6XbThA2Wu7NffnzkX9Lq9Vklnn//JSoilERPNuqMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@navikt/arbeidsgiver-notifikasjon-widget/-/arbeidsgiver-notifikasjon-widget-2.0.3.tgz",
+      "integrity": "sha512-GZlh6UT0BQ3Z9Hg4LTxXfyZ9pa2A/cAo/xphG5oBqxxH+k5erojaLdgnDr5wq0/PeYVzOzaRhf2p5PZQZhd0Eg==",
       "dependencies": {
         "@apollo/client": "3.5.7",
         "@navikt/ds-css": "0.12.13",
@@ -20714,9 +20714,9 @@
       }
     },
     "@navikt/arbeidsgiver-notifikasjon-widget": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@navikt/arbeidsgiver-notifikasjon-widget/-/arbeidsgiver-notifikasjon-widget-2.0.2.tgz",
-      "integrity": "sha512-3UVc6iJlK45n9IssfmsjOUttOUfLQoa137xduEsL6obWC6XbThA2Wu7NffnzkX9Lq9Vklnn//JSoilERPNuqMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@navikt/arbeidsgiver-notifikasjon-widget/-/arbeidsgiver-notifikasjon-widget-2.0.3.tgz",
+      "integrity": "sha512-GZlh6UT0BQ3Z9Hg4LTxXfyZ9pa2A/cAo/xphG5oBqxxH+k5erojaLdgnDr5wq0/PeYVzOzaRhf2p5PZQZhd0Eg==",
       "requires": {
         "@apollo/client": "3.5.7",
         "@navikt/ds-css": "0.12.13",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "/min-side-arbeidsgiver",
   "dependencies": {
     "@craco/craco": "^6.4.3",
-    "@navikt/arbeidsgiver-notifikasjon-widget": "2.0.2",
+    "@navikt/arbeidsgiver-notifikasjon-widget": "2.0.3",
     "@navikt/bedriftsmeny": "3.5.3",
     "@navikt/ds-css": "^0.14.1",
     "@navikt/ds-icons": "^0.7.2",


### PR DESCRIPTION
notifikasjon-widget har egen amplitude client den lager selv internt. Amplitude api nøklene i den gamle versjonen vil straks slutte å fungere.