### PR TITLE
bump setup node

### DIFF
--- a/.github/workflows/bygg-branch.yml
+++ b/.github/workflows/bygg-branch.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: '16.14.2'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          #cache: 'npm'
 
       - run: npm ci
 

--- a/.github/workflows/bygg-branch.yml
+++ b/.github/workflows/bygg-branch.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.14.2'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/bygg-og-deploy-master.yml
+++ b/.github/workflows/bygg-og-deploy-master.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: '16.14.2'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          #cache: 'npm'
 
       - name: Installer avhengigheter
         run:  npm ci --ignore-scripts --no-optional

--- a/.github/workflows/bygg-og-deploy-master.yml
+++ b/.github/workflows/bygg-og-deploy-master.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Sjekk ut kode
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16.14.2'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
bygg etter merge på fredag feilet pga sentry var nede. Rebuild i dag feilet pga npm cache ikke finnes. 
prøver å få master i vater igjen ved å bumpe til siste setup node action og disable cache