### PR TITLE
Fix hent altinn meldingsboks

### DIFF
--- a/src/App/OrganisasjonDetaljerProvider.tsx
+++ b/src/App/OrganisasjonDetaljerProvider.tsx
@@ -35,22 +35,28 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<Props> = ({ childr
         } else {
             setantallAnnonser(0);
         }
+    };
 
-        if (orgInfo.altinntilgang.tilskuddsbrev) {
-            const messagesUrl = reporteeMessagesUrls[org.OrganizationNumber];
+    useEffect(() => {
+        if (valgtOrganisasjon !== undefined && valgtOrganisasjon.altinntilgang.tilskuddsbrev) {
+            const messagesUrl = reporteeMessagesUrls[valgtOrganisasjon.organisasjon.OrganizationNumber];
             if (messagesUrl === undefined) {
                 setAltinnMeldingsboks(undefined);
             } else {
-                const resultat = await hentMeldingsboks(messagesUrl);
-                if (resultat instanceof Error) {
-                    autentiserAltinnBruker(window.location.href);
-                    setAltinnMeldingsboks(undefined);
-                } else {
-                    setAltinnMeldingsboks(resultat);
-                }
+                hentMeldingsboks(messagesUrl)
+                    .then(resultat => {
+                        if (resultat instanceof Error) {
+                            autentiserAltinnBruker(window.location.href);
+                            setAltinnMeldingsboks(undefined);
+                        } else {
+                            setAltinnMeldingsboks(resultat);
+                        }
+                    });
             }
+        } else {
+            setAltinnMeldingsboks(undefined);
         }
-    };
+    }, [valgtOrganisasjon, reporteeMessagesUrls])
 
     useEffect(() => {
         if (valgtOrganisasjon !== undefined && organisasjoner !== undefined) {
@@ -74,6 +80,3 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<Props> = ({ childr
         </OrganisasjonsDetaljerContext.Provider>
     );
 };
-
-export const useValgtOrganisasjon = (): OrganisasjonInfo | undefined =>
-    useContext(OrganisasjonsDetaljerContext).valgtOrganisasjon


### PR DESCRIPTION
Nå hentes meldingsboks kun når virksomhet byttes.
Hvis oversikten over meldingsboks-url-er ikke er klar på det tidspunktet,
så blir ikke meldingsboken hentet. Hvis man bytter fram og tilbake mellom
virksomheter, så vil lastingen bli trigget på nytt, og dukker derfor opp.

Skriver om til å bruke en useEffect som merker om prøver å laste
både hvis virksomhet byttes, og hvis listen over meldingsboks-URL-er oppdateres.