### PR TITLE
kun lag tokenXClient dersom audience er angitt

### DIFF
--- a/server/brukerapi-proxy-middleware.js
+++ b/server/brukerapi-proxy-middleware.js
@@ -63,8 +63,8 @@ const createTokenXClient = async () => {
 
 export const tokenXMiddleware = (
     {
-        tokenXClientPromise = createTokenXClient(),
         audience,
+        tokenXClientPromise = audience ? createTokenXClient() : null,
         log
     }
 ) => async (req, res, next) => {


### PR DESCRIPTION
Labs er i crashloop, pga manglende env var på labs `TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received undefined `

fra 
```
const createTokenXClient = async () => {
    const issuer = await Issuer.discover(TOKEN_X_WELL_KNOWN_URL);
```