### PR TITLE
flytt token fra cookie til header i egen middleware

### DIFF
--- a/server/brukerapi-proxy-middleware.js
+++ b/server/brukerapi-proxy-middleware.js
@@ -74,7 +74,7 @@ export const tokenXMiddleware = (
             return;
         }
 
-        const subject_token = req.cookies['selvbetjening-idtoken'] || (req.headers.authorization || '').replace('Bearer', '').trim();
+        const subject_token = (req.headers.authorization || '').replace('Bearer', '').trim();
         if (subject_token === '') {
             log.info("no authorization header found, skipping tokenx.")
             next();

--- a/server/server.js
+++ b/server/server.js
@@ -162,6 +162,14 @@ app.use(
     }),
 );
 
+app.use('/min-side-arbeidsgiver/api', async  (req, res, next)  => {
+    const subject_token = req.cookies['selvbetjening-idtoken']
+    if (subject_token) {
+        req.headers.authorization = `Bearer ${subject_token}`;
+    }
+    next();
+});
+
 /**
  * onProxyReq does not support async, so using middleware for tokenx instead
  * ref: https://github.com/chimurai/http-proxy-middleware/issues/318


### PR DESCRIPTION
Labs fungerte ikke. Misstenkte det kunne ha med arbeidet med TokenX i backend-en. Flyttet koden som flytter token fra cookie til header ut i en egen middleware som alltid kjøres, uavhengig av om tokenx skjer eller ikke.