### PR TITLE
Endrer til ny URL for "forebygge-fravar" (tidl. "min-ia")

### DIFF
--- a/src/lenker.ts
+++ b/src/lenker.ts
@@ -123,9 +123,9 @@ export const lenkeTilTilgangsstyringsInfo =
     'https://arbeidsgiver.nav.no/min-side-arbeidsgiver/informasjon-om-tilgangsstyring';
 
 export const lenkeTilForebyggefravar = gittMiljo({
-    prod: 'https://arbeidsgiver.nav.no/min-ia/',
-    labs: 'https://arbeidsgiver.labs.nais.io/min-ia/',
-    other: 'https://min-ia.dev.nav.no/min-ia/',
+    prod: 'https://arbeidsgiver.nav.no/forebygge-fravar/',
+    labs: 'https://arbeidsgiver.labs.nais.io/forebygge-fravar/',
+    other: 'https://forebygge-fravar.dev.nav.no/forebygge-fravar/',
 });
 
 export const lenkeTilInfoOmDigitaleSoknader =


### PR DESCRIPTION
PS: Vi har satt opp redirects fra min-ia til forebygge-fravar, så brukerne blir ikke påvirket i særlig grad av URL-endringen