### PR TITLE
Send NAIS_CLUSTER_NAME from frackend

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -62,6 +62,7 @@ const indexHtml = Mustache.render(
         SETTINGS: `
             window.environment = {
                 MILJO: '${NAIS_CLUSTER_NAME}',
+                NAIS_CLUSTER_NAME: '${NAIS_CLUSTER_NAME}',
                 NAIS_APP_IMAGE: '${NAIS_APP_IMAGE}',
                 GIT_COMMIT: '${GIT_COMMIT}',
             }


### PR DESCRIPTION
Når denne er ute, kan man endre frontend til å bruke NAIS_CLUSTER_NAME. Så kan vi endre MILJO til å være faktisk miljø.