### PR TITLE
Stop sending NAIS_CLUSTER_NAME from frackend

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -63,7 +63,6 @@ const indexHtml = Mustache.render(
         SETTINGS: `
             window.environment = {
                 MILJO: '${MILJO}',
-                NAIS_CLUSTER_NAME: '${NAIS_CLUSTER_NAME}',
                 NAIS_APP_IMAGE: '${NAIS_APP_IMAGE}',
                 GIT_COMMIT: '${GIT_COMMIT}',
             }


### PR DESCRIPTION
Frontend no longer uses NAIS_CLUSTER_NAME. 