### PR TITLE
Henter antall saker i OrganisasjonDetaljerProvider

### DIFF
--- a/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
+++ b/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
@@ -42,7 +42,7 @@ const SisteSaker = () => {
 
     if (loading || !data) return null;
 
-    if (data?.saker?.saker?.length === 0 && (antallSakerForAlleBedrifter ?? 0) < 0){
+    if (data.saker?.saker?.length === 0 && (antallSakerForAlleBedrifter ?? 0) > 0){
         return <BodyShort><Link className="lenke" to={{
             pathname: 'saksoversikt',
             search: location.search,

--- a/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
+++ b/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
@@ -42,7 +42,7 @@ const SisteSaker = () => {
 
     if (loading || !data) return null;
 
-    if (data?.saker.saker.length == 0 && antallSakerForAlleBedrifter){
+    if (data?.saker?.saker?.length === 0 && (antallSakerForAlleBedrifter ?? 0) < 0){
         return <BodyShort><Link className="lenke" to={{
             pathname: 'saksoversikt',
             search: location.search,

--- a/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
+++ b/src/App/Hovedside/Sak/SisteSaker/SisteSaker.tsx
@@ -11,12 +11,11 @@ import { OmSaker } from '../OmSaker';
 import { useSessionStateForside } from '../Saksoversikt/useOversiktSessionStorage';
 import { SakSortering } from "../../../../api/graphql-types";
 import { FileFolder } from '@navikt/ds-icons';
-import { useLazyQuery } from '@apollo/client';
 
 const ANTALL_FORSIDESAKER: number = 3;
 
 const SisteSaker = () => {
-    const {valgtOrganisasjon} = useContext(OrganisasjonsDetaljerContext);
+    const {valgtOrganisasjon, antallSakerForAlleBedrifter} = useContext(OrganisasjonsDetaljerContext);
     const location = useLocation()
 
     const { loading, data } = useSaker(ANTALL_FORSIDESAKER, {
@@ -41,7 +40,22 @@ const SisteSaker = () => {
 
     if (valgtOrganisasjon === undefined) return null;
 
-    if (loading || !data || data?.saker.saker.length == 0) return null;
+    if (loading || !data) return null;
+
+    if (data?.saker.saker.length == 0 && antallSakerForAlleBedrifter){
+        return <BodyShort><Link className="lenke" to={{
+            pathname: 'saksoversikt',
+            search: location.search,
+        }} onClick={() => {
+            scroll(0,0);
+            loggNavigasjon("saksoversikt", "se alle saker", location.pathname)
+        }}>
+            <div className='innsynisak__se-alle-saker'>
+                <FileFolder/>
+                Se saker på tvers av alle virksomheter {antallSakerForAlleBedrifter !== undefined ? `(${antallSakerForAlleBedrifter})` : null}
+            </div>
+        </Link></BodyShort>
+    }
 
     return (
         <div className='innsynisak'>
@@ -62,7 +76,7 @@ const SisteSaker = () => {
                     }}>
                         <div className='innsynisak__se-alle-saker'>
                             <FileFolder/>
-                            Se alle saker
+                            Se alle saker {antallSakerForAlleBedrifter !== undefined ? `(${antallSakerForAlleBedrifter})` : null}
                         </div>
                     </Link></BodyShort>
                     : null}

--- a/src/App/OrganisasjonDetaljerProvider.tsx
+++ b/src/App/OrganisasjonDetaljerProvider.tsx
@@ -41,11 +41,8 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<Props> = ({ childr
         if (loading) {
             return;
         }
-
-        if (data !== undefined && data.saker !== undefined && data.saker.totaltAntallSaker !== undefined) {
-            setAntallSakerForAlleBedrifter(data.saker.totaltAntallSaker);
-        }
-    }, [data]);
+        setAntallSakerForAlleBedrifter(data?.saker?.totaltAntallSaker)
+    }, [data, loading]);
 
     const endreOrganisasjon = async (org: Organisasjon) => {
         const orgInfo = organisasjoner[org.OrganizationNumber];

--- a/src/App/OrganisasjonDetaljerProvider.tsx
+++ b/src/App/OrganisasjonDetaljerProvider.tsx
@@ -16,7 +16,7 @@ export type Context = {
     valgtOrganisasjon: OrganisasjonInfo | undefined;
     antallAnnonser: number;
     altinnMeldingsboks: Meldingsboks | undefined;
-    antallSakerForAlleBedrifter: Number | undefined;
+    antallSakerForAlleBedrifter: number | undefined;
 };
 
 export const OrganisasjonsDetaljerContext = React.createContext<Context>({} as Context);
@@ -26,9 +26,9 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<Props> = ({ childr
     const [antallAnnonser, setantallAnnonser] = useState(-1);
     const [valgtOrganisasjon, setValgtOrganisasjon] = useState<OrganisasjonInfo | undefined>(undefined);
     const [altinnMeldingsboks, setAltinnMeldingsboks] = useState<Meldingsboks | undefined>(undefined);
-    const [antallSakerForAlleBedrifter, setAntallSakerForAlleBedrifter] = useState<Number | undefined>(undefined);
+    const [antallSakerForAlleBedrifter, setAntallSakerForAlleBedrifter] = useState<number | undefined>(undefined);
 
-    const { data, loading } = useSaker(1, {
+    const { data, loading } = useSaker(0, {
         side: 1,
         virksomheter: "ALLEBEDRIFTER",
         tekstsoek: '',


### PR DESCRIPTION
Henter antallSaker med useSaker i OrganisasjonDetaljerProvider og sender videre nedover i konteksten. 
Hvis arbeidsgiver er på hovedsiden, og har valgt en virksomhet uten noen saker, vises ikke siste saker. Dersom det likevel finnes saker i en av de andre virksomhetene, vil det stå "Se saker på tvers av alle virksomheter (23)" istedenfor "Se alle saker (23)" 