### PR TITLE
Gamle ingresser i dev skrus av, bruk nye

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Interne henvendelser kan sendes via Slack i kanalen #arbeidsgiver-min-side-arbei
 
 ### Lenker til applikasjon
 
-dev:  https://min-side-arbeidsgiver.dev.nav.no/min-side-arbeidsgiver (i vdi, eller over vpn)
+dev:  https://arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver (med naisdevice)
 prod: https://arbeidsgiver.nav.no/min-side-arbeidsgiver/
-labs: https://arbeidsgiver.labs.nais.io/min-side-arbeidsgiver/
+dev-lik-labs: https://arbeidsgiver-dev-like.ekstern.dev.nav.no/min-side-arbeidsgiver
+prod-lik-labs: https://arbeidsgiver.ekstern.dev.nav.no/min-side-arbeidsgiver
 logs: https://logs.adeo.no/app/dashboards#/view/754c72d0-76d8-11eb-90cb-7315dfb7dea6

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: {{image}}
   ingresses:
-    - https://min-side-arbeidsgiver.dev.nav.no/min-side-arbeidsgiver
+    - https://arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver
   liveness:
     path: /min-side-arbeidsgiver/internal/isAlive
     initialDelay: 20
@@ -33,7 +33,7 @@ spec:
     - name: BACKEND_API_URL
       value: http://min-side-arbeidsgiver-api.fager
     - name: LOGIN_URL
-      value: https://loginservice.dev.nav.no/login?redirect=https://min-side-arbeidsgiver.dev.nav.no/min-side-arbeidsgiver
+      value: https://loginservice.dev.nav.no/login?redirect=https://arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver
     - name: PROXY_LOG_LEVEL
       value: debug
     - name: BRUKER_API_URL


### PR DESCRIPTION
Er nok noen problemer med login i hvert fall, men de har skrudd av gamle ingresser nå, så er vel bare å fikse ting etter hvert som vi finner problemer. Og skrive om til Wonderwall.