### PR TITLE
Handle missing auth header

### DIFF
--- a/server/brukerapi-proxy-middleware.js
+++ b/server/brukerapi-proxy-middleware.js
@@ -14,7 +14,10 @@ export const createNotifikasjonBrukerApiProxyMiddleware = ({ log }) => {
         proxyReqPathResolver: () => '/api/graphql',
         proxyReqOptDecorator: async (options, req) => {
             const tokenXClient = await createTokenXClient();
-            const subject_token = req.headers.authorization.slice("Bearer ".length);
+            const subject_token = (req.headers.authorization || '').replace('Bearer', '').trim();
+            if (subject_token === '') {
+                return Promise.reject("can't exchange token, missing authorization header")
+            }
             const {access_token} = await exchangeToken(tokenXClient, {subject_token, audience});
 
             options.headers.Authorization = `Bearer ${access_token}`;

--- a/server/brukerapi-proxy-middleware.js
+++ b/server/brukerapi-proxy-middleware.js
@@ -10,10 +10,11 @@ const {
 
 export const createNotifikasjonBrukerApiProxyMiddleware = ({ log }) => {
     const audience = `${NAIS_CLUSTER_NAME}:fager:notifikasjon-bruker-api`;
-    const tokenXClient = await createTokenXClient();
+    const tokenXClientPromise = createTokenXClient();
     return expressHttpProxy('http://notifikasjon-bruker-api.fager.svc.cluster.local', {
         proxyReqPathResolver: () => '/api/graphql',
         proxyReqOptDecorator: async (options, req) => {
+            const tokenXClient = await tokenXClientPromise;
             const subject_token = (req.headers.authorization || '').replace('Bearer', '').trim();
             if (subject_token === '') {
                 return Promise.reject("can't exchange token, missing authorization header")

--- a/server/brukerapi-proxy-middleware.js
+++ b/server/brukerapi-proxy-middleware.js
@@ -10,10 +10,10 @@ const {
 
 export const createNotifikasjonBrukerApiProxyMiddleware = ({ log }) => {
     const audience = `${NAIS_CLUSTER_NAME}:fager:notifikasjon-bruker-api`;
+    const tokenXClient = await createTokenXClient();
     return expressHttpProxy('http://notifikasjon-bruker-api.fager.svc.cluster.local', {
         proxyReqPathResolver: () => '/api/graphql',
         proxyReqOptDecorator: async (options, req) => {
-            const tokenXClient = await createTokenXClient();
             const subject_token = (req.headers.authorization || '').replace('Bearer', '').trim();
             if (subject_token === '') {
                 return Promise.reject("can't exchange token, missing authorization header")


### PR DESCRIPTION
Eksisterende kode kaster error, som b.l.a. lager støy i loggene. Håndterer manglende authorization header.

Flytter også oppretting av tokenx-client ut av request handleren, så den lages ved oppstart. Blir ett mindre HTTP-kall når kall mot notifikasjonsplattformen proxies.

Testet i dev.