### PR TITLE
bruk tiltak-proxy for kall mot tiltaksgjennomforing

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -49,13 +49,14 @@ spec:
   accessPolicy:
     outbound:
       external:
-        - host: https://arbeidsgiver-gcp.dev.nav.no
-        - host: https://sykefravarsstatistikk.intern.dev.nav.no
-        - host: https://arbeidsgiver.intern.dev.nav.no
+        - host: arbeidsgiver-gcp.dev.nav.no
+        - host: sykefravarsstatistikk.intern.dev.nav.no
+        - host: arbeidsgiver.intern.dev.nav.no
+        - host: tiltak-proxy.dev-fss-pub.nais.io
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltaksgjennomforing-api
+        - application: tiltak-proxy
           namespace: arbeidsgiver
           cluster: dev-fss
         - application: presenterte-kandidater-api

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -50,10 +50,11 @@ spec:
     outbound:
       external:
         - host: arbeidsgiver.nav.no
+        - host: tiltak-proxy.prod-fss-pub.nais.io
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltaksgjennomforing-api
+        - application: tiltak-proxy
           namespace: arbeidsgiver
           cluster: prod-fss
         - application: presenterte-kandidater-api

--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,6 @@ const {
     NAIS_CLUSTER_NAME = 'local',
     BACKEND_API_URL = 'http://localhost:8080',
     PROXY_LOG_LEVEL = 'info',
-    APIGW_TILTAK_HEADER,
     SYKEFRAVAER_DOMAIN = 'http://localhost:8080',
     MILJO = 'local',
 } = process.env;
@@ -123,8 +122,8 @@ const main = async () => {
                 {
                     log: log,
                     audience: {
-                        'dev': 'dev-fss:arbeidsgiver:tiltaksgjennomforing-api',
-                        'prod': 'prod-fss:arbeidsgiver:tiltaksgjennomforing-api',
+                        'dev': 'dev-fss:arbeidsgiver:tiltak-proxy',
+                        'prod': 'prod-fss:arbeidsgiver:tiltak-proxy',
                     }[MILJO]
                 }),
             createProxyMiddleware({
@@ -158,8 +157,10 @@ const main = async () => {
                 },
                 secure: true,
                 xfwd: true,
-                target: NAIS_CLUSTER_NAME === 'prod-gcp' ? 'https://api-gw.oera.no' : 'https://api-gw-q0.oera.no',
-                ...(APIGW_TILTAK_HEADER ? {headers: {'x-nav-apiKey': APIGW_TILTAK_HEADER}} : {})
+                target: {
+                    'dev': 'https://tiltak-proxy.dev-fss-pub.nais.io',
+                    'prod': 'https://tiltak-proxy.prod-fss-pub.nais.io',
+                }[MILJO],
             }),
         );
 


### PR DESCRIPTION
kall mot tiltaksgjennomforing-api feiler siden forrige uke. 
anbefales å gå vekk fra apigw


se også
- https://github.com/navikt/tiltak-proxy/pull/28
- https://nav-it.slack.com/archives/CA0AX0Y2V/p1683534573510049
- https://nav-it.slack.com/archives/GULF6A7KL/p1683525687289939