### PR TITLE
fjern proxy til sykefraværstatistikk

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -226,22 +226,6 @@ const main = async () => {
             })
         );
 
-        // TODO: fjern denne når vi tenker alle klienter er oppdatert med ny kode
-        app.use(
-            '/min-side-arbeidsgiver/sykefravaer',
-            /* Ingen tokenx her fordi vi går mot deres frackend.
-             * Vi har på backlocken å skrive oss over til kafka-versjonen,
-             * så da blir vi kvitt dette unntaket.
-             */
-            createProxyMiddleware({
-                ...proxyOptions,
-                target: SYKEFRAVAER_DOMAIN,
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/sykefravaer': '/sykefravarsstatistikk/api/',
-                },
-            })
-        );
-
         app.get('/min-side-arbeidsgiver/redirect-til-login', (req, res) => {
             const target = new URL(LOGIN_URL);
             target.searchParams.set('redirect', req.get('referer'));


### PR DESCRIPTION
Merges først når vi ser at det ikke er noe mer trafikk via proxy:
https://prometheus.prod-gcp.nav.cloud.nais.io/graph?g0.expr=sum(increase(http_request_duration_seconds_count%7Bapp%3D%22min-side-arbeidsgiver%22%2C%20method!%3D%22HEAD%22%2C%20route%3D%22%2Fmin-side-arbeidsgiver%2Fsykefravaer%22%7D%5B5m%5D))&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=15m