### PR TITLE
bump http-proxy-middleware til 3.0.0-beta.1 fro graceful shutdown av proxy

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -32,8 +32,6 @@ spec:
   env:
     - name: NODE_EXTRA_CA_CERTS
       value: /etc/ssl/ca-bundle.pem
-    - name: BACKEND_API_URL
-      value: http://min-side-arbeidsgiver-api.fager
     - name: LOGIN_URL
       value: https://arbeidsgiver.intern.dev.nav.no/min-side-arbeidsgiver/oauth2/login
     - name: PROXY_LOG_LEVEL

--- a/nais/labs-gcp.yaml
+++ b/nais/labs-gcp.yaml
@@ -26,8 +26,6 @@ spec:
   env:
     - name: NODE_EXTRA_CA_CERTS
       value: /etc/ssl/ca-bundle.pem
-    - name: BACKEND_API_URL
-      value: http://demo-min-side-arbeidsgiver-api.fager
     - name: LOGIN_URL
       value: https://arbeidsgiver.ekstern.dev.nav.no/fake-login/login?issuer=selvbetjening&sub=123456789&domain=arbeidsgiver.ekstern.dev.nav.no&redirect=https://arbeidsgiver.ekstern.dev.nav.no/min-side-arbeidsgiver/
     - name: PROXY_LOG_LEVEL

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -32,8 +32,6 @@ spec:
   env:
     - name: NODE_EXTRA_CA_CERTS
       value: /etc/ssl/ca-bundle.pem
-    - name: BACKEND_API_URL
-      value: http://min-side-arbeidsgiver-api.fager
     - name: LOGIN_URL
       value: https://arbeidsgiver.nav.no/min-side-arbeidsgiver/oauth2/login
     - name: PROXY_LOG_LEVEL

--- a/server/mock/antallArbeidsforholdMock.js
+++ b/server/mock/antallArbeidsforholdMock.js
@@ -1,9 +1,12 @@
 export const mock = (app) => {
-    app.use('/min-side-arbeidsgiver/antall-arbeidsforhold', (req, res) => {
-        const antall = 502;
-        const missing = Math.floor(Math.random() * 10) === 0;
-        setTimeout(() => {
-            res.send({ first: '131488434', second: missing ? -1 : antall });
-        }, 1000);
-    });
+    app.use(
+        '/min-side-arbeidsgiver/arbeidsgiver-arbeidsforhold-api/antall-arbeidsforhold',
+        (req, res) => {
+            const antall = 502;
+            const missing = Math.floor(Math.random() * 10) === 0;
+            setTimeout(() => {
+                res.send({ first: '131488434', second: missing ? -1 : antall });
+            }, 1000);
+        }
+    );
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "^1.4.6",
         "express": "^4.17.3",
         "express-http-proxy": "1.6.3",
-        "http-proxy-middleware": "^1.0.6",
+        "http-proxy-middleware": "3.0.0-beta.1",
         "jsdom": "^16.4.0",
         "mustache": "^4.2.0",
         "node-fetch": "^3.2.10",
@@ -440,9 +440,9 @@
       "integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q=="
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
-      "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz",
+      "integrity": "sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1540,19 +1540,41 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/http-proxy-middleware": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
-      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0-beta.1.tgz",
+      "integrity": "sha512-hdiTlVVoaxncf239csnEpG5ew2lRWnoNR1PMWOO6kYulSphlrfLs5JFZtFVH3R5EUWSZNMkeUqvkvfctuWaK8A==",
       "dependencies": {
-        "@types/http-proxy": "^1.17.5",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -1827,12 +1849,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -2037,9 +2059,9 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -2999,9 +3021,9 @@
       "integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q=="
     },
     "@types/http-proxy": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.7.tgz",
-      "integrity": "sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==",
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz",
+      "integrity": "sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==",
       "requires": {
         "@types/node": "*"
       }
@@ -3844,15 +3866,31 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
-      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+      "version": "3.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0-beta.1.tgz",
+      "integrity": "sha512-hdiTlVVoaxncf239csnEpG5ew2lRWnoNR1PMWOO6kYulSphlrfLs5JFZtFVH3R5EUWSZNMkeUqvkvfctuWaK8A==",
       "requires": {
-        "@types/http-proxy": "^1.17.5",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "https-proxy-agent": {
@@ -4061,12 +4099,12 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -4203,9 +4241,9 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pkginfo": {
       "version": "0.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "cookie-parser": "^1.4.6",
     "express": "^4.17.3",
     "express-http-proxy": "1.6.3",
-    "http-proxy-middleware": "^1.0.6",
+    "http-proxy-middleware": "3.0.0-beta.1",
     "jsdom": "^16.4.0",
     "mustache": "^4.2.0",
     "node-fetch": "^3.2.10",

--- a/server/server.js
+++ b/server/server.js
@@ -20,7 +20,6 @@ const {
     GIT_COMMIT = '?',
     LOGIN_URL = 'http://localhost:8080/ditt-nav-arbeidsgiver-api/local/selvbetjening-login?redirect=http://localhost:3000/min-side-arbeidsgiver',
     NAIS_CLUSTER_NAME = 'local',
-    BACKEND_API_URL = 'http://localhost:8080',
     PROXY_LOG_LEVEL = 'info',
     MILJO = 'local',
 } = process.env;
@@ -36,7 +35,7 @@ const log = new Proxy(
         transports: [
             new transports.Console({
                 timestamp: true,
-                format: format.json(),
+                format: format.combine(format.splat(), format.json()),
             }),
         ],
     }),
@@ -132,7 +131,7 @@ const main = async () => {
             changeOrigin: true,
         };
         app.use(
-            '/min-side-arbeidsgiver/tiltaksgjennomforing-api/avtaler',
+            '/min-side-arbeidsgiver/tiltaksgjennomforing-api',
             tokenXMiddleware({
                 log: log,
                 audience: {
@@ -149,7 +148,7 @@ const main = async () => {
                         try {
                             if (proxyRes.statusCode >= 400) {
                                 log.warn(
-                                    `tiltaksgjennomforing-api/avtaler feilet ${proxyRes.statusCode}: ${proxyRes.statusMessage}`
+                                    `tiltaksgjennomforing-api feilet ${proxyRes.statusCode}: ${proxyRes.statusMessage}`
                                 );
                                 return JSON.stringify([]);
                             }
@@ -162,23 +161,20 @@ const main = async () => {
                                 return JSON.stringify(data);
                             }
                         } catch (error) {
-                            log.error(`tiltaksgjennomforing-api/avtaler feilet ${error}`);
+                            log.error(`tiltaksgjennomforing-api feilet ${error}`);
                             return JSON.stringify([]);
                         }
                     }),
                 },
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/': '/',
-                },
                 target: {
-                    dev: 'https://tiltak-proxy.dev-fss-pub.nais.io',
-                    prod: 'https://tiltak-proxy.prod-fss-pub.nais.io',
+                    dev: 'https://tiltak-proxy.dev-fss-pub.nais.io/tiltaksgjennomforing-api',
+                    prod: 'https://tiltak-proxy.prod-fss-pub.nais.io/tiltaksgjennomforing-api',
                 }[MILJO],
             })
         );
 
         app.use(
-            '/min-side-arbeidsgiver/presenterte-kandidater-api/ekstern/antallkandidater',
+            '/min-side-arbeidsgiver/presenterte-kandidater-api',
             tokenXMiddleware({
                 log: log,
                 audience: {
@@ -188,15 +184,12 @@ const main = async () => {
             }),
             createProxyMiddleware({
                 ...proxyOptions,
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/presenterte-kandidater-api/ekstern': '/ekstern',
-                },
                 target: 'http://presenterte-kandidater-api.toi',
             })
         );
 
         app.use(
-            '/min-side-arbeidsgiver/antall-arbeidsforhold',
+            '/min-side-arbeidsgiver/arbeidsgiver-arbeidsforhold-api',
             tokenXMiddleware({
                 log: log,
                 audience: {
@@ -206,13 +199,9 @@ const main = async () => {
             }),
             createProxyMiddleware({
                 ...proxyOptions,
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/antall-arbeidsforhold':
-                        '/arbeidsgiver-arbeidsforhold-api/antall-arbeidsforhold',
-                },
                 target: {
-                    dev: 'https://aareg-innsyn-arbeidsgiver-api.dev-fss-pub.nais.io',
-                    prod: 'https://aareg-innsyn-arbeidsgiver-api.prod-fss-pub.nais.io',
+                    dev: 'https://aareg-innsyn-arbeidsgiver-api.dev-fss-pub.nais.io/arbeidsgiver-arbeidsforhold-api',
+                    prod: 'https://aareg-innsyn-arbeidsgiver-api.prod-fss-pub.nais.io/arbeidsgiver-arbeidsforhold-api',
                 }[MILJO],
             })
         );
@@ -228,10 +217,7 @@ const main = async () => {
             }),
             createProxyMiddleware({
                 ...proxyOptions,
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/api': '/ditt-nav-arbeidsgiver-api/api',
-                },
-                target: BACKEND_API_URL,
+                target: 'http://min-side-arbeidsgiver-api.fager.svc.cluster.local/ditt-nav-arbeidsgiver-api/api',
             })
         );
 
@@ -246,10 +232,7 @@ const main = async () => {
             }),
             createProxyMiddleware({
                 ...proxyOptions,
-                target: 'http://notifikasjon-bruker-api.fager.svc.cluster.local',
-                pathRewrite: {
-                    '^/min-side-arbeidsgiver/notifikasjon-bruker-api': '/api/graphql',
-                },
+                target: 'http://notifikasjon-bruker-api.fager.svc.cluster.local/api/graphql',
             })
         );
 
@@ -279,24 +262,6 @@ const main = async () => {
     app.get('/min-side-arbeidsgiver/*', (req, res) => {
         res.send(indexHtml);
     });
-
-    if (MILJO === 'dev' || MILJO === 'prod') {
-        const gauge = new Prometheus.Gauge({
-            name: 'backend_api_gw',
-            help: 'Hvorvidt frontend-server naar backend-server. up=1, down=0',
-        });
-        setInterval(async () => {
-            try {
-                const res = await fetch(
-                    `${BACKEND_API_URL}/ditt-nav-arbeidsgiver-api/internal/actuator/health`
-                );
-                gauge.set(res.ok ? 1 : 0);
-            } catch (error) {
-                log.error(`healthcheck error: ${gauge.name}`, error);
-                gauge.set(0);
-            }
-        }, 60 * 1000);
-    }
 
     const server = app.listen(PORT, () => {
         log.info(`Server listening on port ${PORT}`);

--- a/server/server.js
+++ b/server/server.js
@@ -232,6 +232,7 @@ const main = async () => {
             }),
             createProxyMiddleware({
                 ...proxyOptions,
+                pathRewrite: { '^/': '' },
                 target: 'http://notifikasjon-bruker-api.fager.svc.cluster.local/api/graphql',
             })
         );

--- a/src/App/Hovedside/TjenesteBoksContainer/Arbeidsforholdboks/useAntallArbeidsforholdFraAareg.ts
+++ b/src/App/Hovedside/TjenesteBoksContainer/Arbeidsforholdboks/useAntallArbeidsforholdFraAareg.ts
@@ -9,7 +9,7 @@ export const useAntallArbeidsforholdFraAareg = (): number => {
     const { data } = useSWR(
         valgtOrganisasjon !== undefined
             ? {
-                  url: '/min-side-arbeidsgiver/antall-arbeidsforhold',
+                  url: '/min-side-arbeidsgiver/arbeidsgiver-arbeidsforhold-api/antall-arbeidsforhold',
                   jurenhet: valgtOrganisasjon.organisasjon.ParentOrganizationNumber ?? '',
                   orgnr: valgtOrganisasjon.organisasjon.OrganizationNumber,
               }


### PR DESCRIPTION
denne må testes i dev, da det er en del breaking changes: https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md

Har gått gjennom changelog og migration guide, så tror det skal være i orden.

---

- [x] testet i dev