### PR TITLE
fjern cookie header fra proxy requests

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,6 @@
                 "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock": "6.4.0",
                 "apollo-server-express": "3.12.1",
                 "casual": "^1.6.2",
-                "cookie-parser": "^1.4.6",
                 "express": "^4.17.3",
                 "express-http-proxy": "1.6.3",
                 "http-proxy-middleware": "3.0.0-beta.1",
@@ -1029,26 +1028,6 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/cookie-parser": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-            "dependencies": {
-                "cookie": "0.4.1",
-                "cookie-signature": "1.0.6"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/cookie-signature": {
@@ -3701,20 +3680,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-        },
-        "cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        },
-        "cookie-parser": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-            "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-            "requires": {
-                "cookie": "0.4.1",
-                "cookie-signature": "1.0.6"
-            }
         },
         "cookie-signature": {
             "version": "1.0.6",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,6 @@
         "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock": "6.4.0",
         "apollo-server-express": "3.12.1",
         "casual": "^1.6.2",
-        "cookie-parser": "^1.4.6",
         "express": "^4.17.3",
         "express-http-proxy": "1.6.3",
         "http-proxy-middleware": "3.0.0-beta.1",

--- a/server/server.js
+++ b/server/server.js
@@ -66,9 +66,8 @@ const log = new Proxy(
 
 const cookieScraperPlugin = (proxyServer, options) => {
     proxyServer.on('proxyReq', (proxyReq, req, res, options) => {
-        if (proxyReq.header['cookie']) {
-            log.info('removing cookie from proxyReq. size=', proxyReq.header['cookie'].size);
-            delete proxyReq.header['cookie'];
+        if (proxyReq.getHeader('cookie')) {
+            proxyReq.removeHeader('cookie');
         }
     });
 };

--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,6 @@ import httpProxyMiddleware, {
 import { createHttpTerminator } from 'http-terminator';
 import Prometheus from 'prom-client';
 import { createLogger, format, transports } from 'winston';
-import cookieParser from 'cookie-parser';
 import { tokenXMiddleware } from './tokenx.js';
 import { readFileSync } from 'fs';
 import require from './esm-require.js';
@@ -67,7 +66,10 @@ const log = new Proxy(
 
 const cookieScraperPlugin = (proxyServer, options) => {
     proxyServer.on('proxyReq', (proxyReq, req, res, options) => {
-        delete proxyReq.header['cookie'];
+        if (proxyReq.header['cookie']) {
+            log.info('removing cookie from proxyReq. size=', proxyReq.header['cookie'].size);
+            delete proxyReq.header['cookie'];
+        }
     });
 };
 // copy with mods from http-proxy-middleware https://github.com/chimurai/http-proxy-middleware/blob/master/src/plugins/default/logger-plugin.ts
@@ -144,7 +146,6 @@ const main = async () => {
     const app = express();
     app.disable('x-powered-by');
     app.set('views', BUILD_PATH);
-    app.use(cookieParser());
 
     app.use('/*', (req, res, next) => {
         res.setHeader('NAIS_APP_IMAGE', NAIS_APP_IMAGE);

--- a/server/server.js
+++ b/server/server.js
@@ -65,6 +65,11 @@ const log = new Proxy(
     }
 );
 
+const cookieScraperPlugin = (proxyServer, options) => {
+    proxyServer.on('proxyReq', (proxyReq, req, res, options) => {
+        delete proxyReq.header['cookie'];
+    });
+};
 // copy with mods from http-proxy-middleware https://github.com/chimurai/http-proxy-middleware/blob/master/src/plugins/default/logger-plugin.ts
 const loggerPlugin = (proxyServer, options) => {
     proxyServer.on('error', (err, req, res, target) => {
@@ -198,7 +203,13 @@ const main = async () => {
             xfwd: true,
             changeOrigin: true,
             ejectPlugins: true,
-            plugins: [debugProxyErrorsPlugin, errorResponsePlugin, loggerPlugin, proxyEventsPlugin],
+            plugins: [
+                cookieScraperPlugin,
+                debugProxyErrorsPlugin,
+                errorResponsePlugin,
+                loggerPlugin,
+                proxyEventsPlugin,
+            ],
         };
         app.use(
             '/min-side-arbeidsgiver/tiltaksgjennomforing-api',


### PR DESCRIPTION
vi får noen [HTTP 431](https://sentry.gc.nav.no/organizations/nav/issues/512219/?referrer=slack) som tyder på at vi videresender cookies gjennom proxyen. 
Denne PR legger til en ligen plugin som fjerner cookie header fra alle proxt requests dersom det finnes. 
Fjerner også cookie parser plugin. Den er ikke i bruk.
- [x] Testet lokalt og i dev.