### PR TITLE
Lag releases med sentrys vite plugin

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,6 +37,8 @@ jobs:
             - run: npm run build
               env:
                   PUBLIC_URL: https://cdn.nav.no/fager/min-side-arbeidsgiver/build/
+                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  SENTRY_LOG_LEVEL: info
 
             - uses: nais/docker-build-push@v0
               id: dockerpush
@@ -52,17 +54,6 @@ jobs:
                   cdn-team-name: fager
                   source: ./build/
                   destination: '/min-side-arbeidsgiver'
-
-            - name: Lag sentry release
-              continue-on-error: true
-              env:
-                  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-              run: |
-                  npx -p @sentry/cli sentry-cli releases new "${{ github.sha }}"
-                  npx -p @sentry/cli sentry-cli releases files "${{ github.sha }}" upload-sourcemaps build/static/js \
-                      --url-prefix '~/min-side-arbeidsgiver/static/js'
-                  npx -p @sentry/cli sentry-cli releases set-commits --auto "${{ github.sha }}"
-                  npx -p @sentry/cli sentry-cli releases finalize "${{ github.sha }}"
 
             - name: Deploy til dev-gcp
               uses: nais/deploy/actions/deploy@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
                 "@navikt/ds-react": "^4.9.0",
                 "@navikt/nav-dekoratoren-moduler": "2.1.3",
                 "@sentry/react": "^6.7.0",
+                "@sentry/vite-plugin": "^2.8.0",
                 "@types/amplitude-js": "^8.9.0",
+                "@types/node": "^18.18.4",
                 "@types/react": "17.0.38",
                 "@types/react-dom": "17.0.11",
                 "@types/uuid": "^9.0.2",
@@ -2687,8 +2689,7 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.19",
@@ -3193,6 +3194,53 @@
             "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
             "dev": true
         },
+        "node_modules/@sentry-internal/tracing": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.73.0.tgz",
+            "integrity": "sha512-ig3WL/Nqp8nRQ52P205NaypGKNfIl/G+cIqge9xPW6zfRb5kJdM1YParw9GSJ1SPjEZBkBORGAML0on5H2FILw==",
+            "dependencies": {
+                "@sentry/core": "7.73.0",
+                "@sentry/types": "7.73.0",
+                "@sentry/utils": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+            "integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+            "dependencies": {
+                "@sentry/types": "7.73.0",
+                "@sentry/utils": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+            "integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+            "integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+            "dependencies": {
+                "@sentry/types": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@sentry/browser": {
             "version": "6.19.7",
             "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.7.tgz",
@@ -3211,6 +3259,125 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@sentry/bundler-plugin-core": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.8.0.tgz",
+            "integrity": "sha512-DsTUgeKPqck3DkGzKjRduhPpEn0pez+/THF3gpwQBEfbPnKGr0EYugDvfungZwBFenckIvQBDTOZw0STvbgChA==",
+            "dependencies": {
+                "@sentry/cli": "^2.21.2",
+                "@sentry/node": "^7.60.0",
+                "@sentry/utils": "^7.60.0",
+                "dotenv": "^16.3.1",
+                "find-up": "5.0.0",
+                "glob": "9.3.2",
+                "magic-string": "0.27.0",
+                "unplugin": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/types": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+            "integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/utils": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+            "integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+            "dependencies": {
+                "@sentry/types": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+            "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^7.4.1",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/cli": {
+            "version": "2.21.2",
+            "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.2.tgz",
+            "integrity": "sha512-X1nye89zl+QV3FSuQDGItfM51tW9PQ7ce0TtV/12DgGgTVEgnVp5uvO3wX5XauHvulQzRPzwUL3ZK+yS5bAwCw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "https-proxy-agent": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "progress": "^2.0.3",
+                "proxy-from-env": "^1.1.0",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "sentry-cli": "bin/sentry-cli"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@sentry/cli/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/@sentry/core": {
             "version": "6.19.7",
@@ -3268,6 +3435,80 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
+        "node_modules/@sentry/node": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.73.0.tgz",
+            "integrity": "sha512-i50bRfmgkRRx0XXUbg9jGD/RuznDJxJXc4rBILhoJuhl+BjRIaoXA3ayplfJn8JLZxsNh75uJaCq4IUK70SORw==",
+            "dependencies": {
+                "@sentry-internal/tracing": "7.73.0",
+                "@sentry/core": "7.73.0",
+                "@sentry/types": "7.73.0",
+                "@sentry/utils": "7.73.0",
+                "cookie": "^0.5.0",
+                "https-proxy-agent": "^5.0.0",
+                "lru_map": "^0.3.3",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@sentry/core": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+            "integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+            "dependencies": {
+                "@sentry/types": "7.73.0",
+                "@sentry/utils": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@sentry/types": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+            "integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/@sentry/utils": {
+            "version": "7.73.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+            "integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+            "dependencies": {
+                "@sentry/types": "7.73.0",
+                "tslib": "^2.4.1 || ^1.9.3"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/@sentry/node/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/@sentry/react": {
             "version": "6.19.7",
             "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.19.7.tgz",
@@ -3316,6 +3557,18 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@sentry/vite-plugin": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.8.0.tgz",
+            "integrity": "sha512-17++vXjfn0xEfE7W4FWdwoXdNNqGjXnuTvIgSLlhJvDCTcqWONDpA/TGXGLjbhQEmQ58wL4wQqmlyxoqMPlokQ==",
+            "dependencies": {
+                "@sentry/bundler-plugin-core": "2.8.0",
+                "unplugin": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/@swc/core": {
             "version": "1.3.86",
@@ -3564,10 +3817,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.17.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
-            "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
-            "devOptional": true
+            "version": "18.18.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
+            "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ=="
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -4097,7 +4349,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -4380,7 +4631,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4622,7 +4872,6 @@
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
             "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4828,6 +5077,14 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true
+        },
+        "node_modules/cookie": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/core-js": {
             "version": "3.32.2",
@@ -5205,7 +5462,6 @@
             "version": "16.3.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
             "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5861,7 +6117,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -6679,7 +6934,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -7631,7 +7885,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -7734,6 +7987,11 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/lru_map": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+            "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7741,6 +7999,17 @@
             "dev": true,
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.13"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/make-error": {
@@ -7854,6 +8123,14 @@
                 "node": "*"
             }
         },
+        "node_modules/minipass": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7924,7 +8201,6 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -7943,20 +8219,17 @@
         "node_modules/node-fetch/node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "node_modules/node-fetch/node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "node_modules/node-fetch/node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -7999,7 +8272,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8414,7 +8686,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -8585,6 +8856,37 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/path-scurry": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+            "dependencies": {
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+            "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+            "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -8681,6 +8983,14 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/promise": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -8699,6 +9009,11 @@
                 "object-assign": "^4.1.1",
                 "react-is": "^16.13.1"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/psl": {
             "version": "1.9.0",
@@ -8898,7 +9213,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -10011,6 +10325,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/unplugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+            "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+            "dependencies": {
+                "acorn": "^8.8.1",
+                "chokidar": "^3.5.3",
+                "webpack-sources": "^3.2.3",
+                "webpack-virtual-modules": "^0.5.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -10274,6 +10599,19 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+            "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw=="
         },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
         "@navikt/ds-react": "^4.9.0",
         "@navikt/nav-dekoratoren-moduler": "2.1.3",
         "@sentry/react": "^6.7.0",
+        "@sentry/vite-plugin": "^2.8.0",
         "@types/amplitude-js": "^8.9.0",
+        "@types/node": "^18.18.4",
         "@types/react": "17.0.38",
         "@types/react-dom": "17.0.11",
         "@types/uuid": "^9.0.2",
@@ -43,8 +45,8 @@
         "@graphql-codegen/typescript-react-apollo": "^3.3.3",
         "husky": "^8.0.3",
         "lint-staged": "^14.0.0",
-        "prettier": "^3.0.2",
-        "npm-run-all": "*"
+        "npm-run-all": "*",
+        "prettier": "^3.0.2"
     },
     "scripts": {
         "gql:cp_schema": "cp ../arbeidsgiver-notifikasjon-produsent-api/app/src/main/resources/bruker.graphql ./bruker.graphql",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,24 @@
 import { defineConfig } from 'vite';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: '/',
-    plugins: [react()],
+    plugins: [
+        react(),
+        sentryVitePlugin({
+            url: 'https://sentry.gc.nav.no/',
+            org: 'nav',
+            project: 'min-side-arbeidsgiver',
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            release: {
+                name: process.env.GITHUB_SHA,
+                // onprem trenger legacy upload
+                uploadLegacySourcemaps: './build/assets',
+            },
+        }),
+    ],
     build: {
         outDir: 'build',
         sourcemap: true,


### PR DESCRIPTION
Nytt forsøk på å få sourcemaps i sentry.

Fungerer fortsatt å kjøre lokalt, får bare warning:
> [sentry-vite-plugin] Warning: No auth token provided. Will not create release. Please set the `authToken` option. You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/

Ser ut til at det fungerer sånn halvveis i hvert fall. Feilmelding om "no release found" i [CICD](https://github.com/navikt/min-side-arbeidsgiver/actions/runs/6495835230/job/17641556270), men det dukker opp sourcemaps i [releasen]( https://sentry.gc.nav.no/organizations/nav/releases/f98ea50c97435c7601f692e9241679a15f1bcde7/?project=27)

Kunne kanskje alternativt prøvd å detektere i `vite.config.ts` om man er i CI, for å inkludere plugingen dynamisk? Men tenker det er lurt å finne ut om det i det hele tatt fungerer, før vi finner ut om hvordan man gjør det dynamisk.