### PR TITLE
Spesifiser prefix for sentry-assets

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
             release: {
                 name: process.env.GITHUB_SHA,
                 // onprem trenger legacy upload
-                uploadLegacySourcemaps: './build/assets',
+                uploadLegacySourcemaps: {
+                    paths: ['./build/assets'],
+                    urlPrefix: '/fager/min-side-arbeidsgiver/build/assets/',
+                },
             },
         }),
     ],


### PR DESCRIPTION
Med denne ser articatene slik ut,
<img width="1256" alt="image" src="https://github.com/navikt/min-side-arbeidsgiver/assets/789911/a2b187c6-ddd6-4d59-acb4-ca2dfea81f30">

noe som matcher formen i feilmeldingene vi får

<img width="1256" alt="image" src="https://github.com/navikt/min-side-arbeidsgiver/assets/789911/7e7cd171-0544-4a43-9f0f-b6364c658c82">
