### PR TITLE
Prøv tilde i source map prefix

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
                 // onprem trenger legacy upload
                 uploadLegacySourcemaps: {
                     paths: ['./build/assets'],
-                    urlPrefix: '/fager/min-side-arbeidsgiver/build/assets/',
+                    urlPrefix: '~/fager/min-side-arbeidsgiver/build/assets/',
                 },
             },
         }),


### PR DESCRIPTION
ser ut til at noen mener det er nødvendig: https://forum.sentry.io/t/javascript-sourcemap-is-not-used/1012