### PR TITLE
cache index max 1 time

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -353,6 +353,7 @@ const main = async () => {
     });
 
     app.get('/min-side-arbeidsgiver/*', (req, res) => {
+        res.setHeader('Cache-Control', 'public, max-age=3600');
         res.send(indexHtml);
     });
 


### PR DESCRIPTION
Jeg mistenker at grunnen til at vi får så mange gamle klienter, er at vi har default caching med etags på index routen.
Tenker det er verdt et forsøk å sette max-age 1 time på index.html