### PR TITLE
Fiks mutation-bug i AlertProvider.

### DIFF
--- a/src/App/Hovedside/Sak/useSaker.tsx
+++ b/src/App/Hovedside/Sak/useSaker.tsx
@@ -170,14 +170,11 @@ export function useSaker(
         error,
     ]);
 
-    const { addAlert, clearAlert } = useContext(AlertContext);
-
+    const { setSystemAlert } = useContext(AlertContext);
+    const feilAltinn = data?.saker.feilAltinn ?? false;
     useEffect(() => {
-        if (data?.saker.feilAltinn ?? false) {
-            addAlert('Saker');
-        } else {
-            clearAlert('Saker');
-        }
-    }, [data]);
+        setSystemAlert('SakerAltinn', feilAltinn);
+    }, [feilAltinn]);
+
     return { loading, data, previousData };
 }

--- a/src/App/OrganisasjonerOgTilgangerProvider.tsx
+++ b/src/App/OrganisasjonerOgTilgangerProvider.tsx
@@ -138,7 +138,7 @@ export const OrganisasjonerOgTilgangerProvider: FunctionComponent = (props) => {
     const [alleRefusjonsstatus, setAlleRefusjonsstatus] = useState<RefusjonStatus[] | undefined>(
         undefined
     );
-    const { addAlert } = useContext(AlertContext);
+    const { setSystemAlert } = useContext(AlertContext);
     const altinnTilgangssøknader = useAltinnTilgangssøknader();
     const userInfo = useUserInfo();
     useEffect(() => {
@@ -146,12 +146,9 @@ export const OrganisasjonerOgTilgangerProvider: FunctionComponent = (props) => {
             // ikke set organisasjoner og tilganger før de er lastet
             return;
         }
-        if (userInfo.altinnError) {
-            addAlert('TilgangerAltinn');
-        }
-        if (userInfo.digisyfoError) {
-            addAlert('TilgangerDigiSyfo');
-        }
+
+        setSystemAlert('UserInfoAltinn', userInfo.altinnError);
+        setSystemAlert('UserInfoDigiSyfo', userInfo.digisyfoError);
         setAltinnorganisasjoner(userInfo.organisasjoner);
         setAltinntilganger(userInfo.tilganger);
         setSyfoVirksomheter(userInfo.digisyfoOrganisasjoner);


### PR DESCRIPTION
AlertProvider brukte den innebygde typen `Set`, som kun kan brukes med mutering. Kopieringen `new Set(...)` for å kompansere for dette var plassert feil. Bytter til `Set` fra immutable-biblioteket så er det umulig™ å gjøre feil.

Endret API-et til å settes ved boolean, siden det virker mer hensiktsmessig med bruken.


- [x] Testet i dev ved å blokkere/åpne for userInfo