### PR TITLE
Flytter altinn tilgangssøknader ut av kritisk path

### DIFF
--- a/src/App/Hovedside/BeOmTilgang/BeOmTilgang.tsx
+++ b/src/App/Hovedside/BeOmTilgang/BeOmTilgang.tsx
@@ -1,6 +1,9 @@
 import React, { FC, FunctionComponent, MouseEventHandler, useContext } from 'react';
 import { Ekspanderbartpanel } from '../../../GeneriskeElementer/Ekspanderbartpanel';
-import { OrganisasjonInfo } from '../../OrganisasjonerOgTilgangerProvider';
+import {
+    OrganisasjonerOgTilgangerContext,
+    OrganisasjonInfo,
+} from '../../OrganisasjonerOgTilgangerProvider';
 import { OrganisasjonsDetaljerContext } from '../../OrganisasjonDetaljerProvider';
 import Organisasjonsbeskrivelse from './Organisasjonsbeskrivelse/Organisasjonsbeskrivelse';
 import {
@@ -75,6 +78,8 @@ const opprettSøknad = (
 
 const BeOmTilgang: FunctionComponent = () => {
     const { valgtOrganisasjon } = useContext(OrganisasjonsDetaljerContext);
+    const { altinnTilgangssøknad } = useContext(OrganisasjonerOgTilgangerContext);
+
     const tjenesteinfoBokser: JSX.Element[] = [];
     if (valgtOrganisasjon === undefined) {
         return null;
@@ -96,12 +101,14 @@ const BeOmTilgang: FunctionComponent = () => {
     }
 
     if (valgtOrganisasjon.reporteetilgang) {
+        const tilgangssøknader =
+            altinnTilgangssøknad?.[valgtOrganisasjon.organisasjon.OrganizationNumber];
         for (let altinnId of altinnIdIRekkefølge) {
             const tilgang = valgtOrganisasjon.altinntilgang[altinnId];
-            const tilgangsøknad = valgtOrganisasjon.altinnsøknad[altinnId];
+            const tilgangsøknad = tilgangssøknader?.[altinnId];
             if (tilgang === true) {
                 /* har tilgang -- ingen ting å vise */
-            } else if (tilgangsøknad.tilgang === 'ikke søkt') {
+            } else if (tilgangsøknad === undefined || tilgangsøknad.tilgang === 'ikke søkt') {
                 tjenesteinfoBokser.push(
                     <BeOmTilgangBoks
                         altinnId={altinnId}

--- a/src/App/OrganisasjonerOgTilgangerProvider.tsx
+++ b/src/App/OrganisasjonerOgTilgangerProvider.tsx
@@ -195,10 +195,14 @@ export const OrganisasjonerOgTilgangerProvider: FunctionComponent = (props) => {
         [organisasjonstre]
     );
 
-    const altinnTilgangssøknad = beregnAltinnTilgangssøknad(
-        altinnorganisasjoner,
-        altinntilganger,
-        altinnTilgangssøknader
+    const altinnTilgangssøknad = useMemo(
+        () =>
+            beregnAltinnTilgangssøknad(
+                altinnorganisasjoner,
+                altinntilganger,
+                altinnTilgangssøknader
+            ),
+        [altinnorganisasjoner, altinntilganger, altinnTilgangssøknader]
     );
 
     if (organisasjoner === undefined || organisasjonstre === undefined) {


### PR DESCRIPTION
Nå kan siden rendre, uten at tilgangssøknader er ferdig lastet.

Det nok åpner opp for refactorings, men har ikke tatt det med i denne PR-en.

- [x] test dev