### PR TITLE
useUserInfo uten default value

### DIFF
--- a/src/App/LoginBoundary.tsx
+++ b/src/App/LoginBoundary.tsx
@@ -2,21 +2,31 @@ import React, { FunctionComponent } from 'react';
 import { Spinner } from './Spinner';
 import { SimpleBanner } from './HovedBanner/HovedBanner';
 import { useUserInfo } from './useUserInfo';
+import { Alert } from '@navikt/ds-react';
 
 export const LoginBoundary: FunctionComponent = (props) => {
-    const { loaded, errorStatus } = useUserInfo();
+    const { userInfo, errorStatus, isError } = useUserInfo();
 
-    if (errorStatus === 401) {
+    if (userInfo !== undefined) {
+        return <>{props.children}</>;
+    } else if (errorStatus === 401) {
         window.location.href = '/min-side-arbeidsgiver/redirect-til-login';
         return null;
-    } else if (!loaded) {
+    } else if (isError) {
+        return (
+            <>
+                <SimpleBanner />
+                <div style={{ width: '60rem', margin: '32px auto' }}>
+                    <Alert variant="error">Uventet feil. Prøv å last siden på nytt.</Alert>
+                </div>
+            </>
+        );
+    } else {
         return (
             <>
                 <SimpleBanner />
                 <Spinner />
             </>
         );
-    } else {
-        return <>{props.children}</>;
     }
 };

--- a/src/App/OrganisasjonerOgTilgangerProvider.tsx
+++ b/src/App/OrganisasjonerOgTilgangerProvider.tsx
@@ -143,21 +143,21 @@ export const OrganisasjonerOgTilgangerProvider: FunctionComponent = (props) => {
     );
     const { setSystemAlert } = useContext(AlertContext);
     const altinnTilgangssøknader = useAltinnTilgangssøknader();
-    const userInfo = useUserInfo();
+    const { userInfo } = useUserInfo();
     useEffect(() => {
-        if (!userInfo.loaded) {
-            // ikke set organisasjoner og tilganger før de er lastet
+        setSystemAlert('UserInfoAltinn', userInfo?.altinnError ?? false);
+        setSystemAlert('UserInfoDigiSyfo', userInfo?.digisyfoError ?? false);
+
+        if (userInfo === undefined) {
             return;
         }
 
-        setSystemAlert('UserInfoAltinn', userInfo.altinnError);
-        setSystemAlert('UserInfoDigiSyfo', userInfo.digisyfoError);
         setAltinnorganisasjoner(userInfo.organisasjoner);
         setAltinntilganger(userInfo.tilganger);
         setSyfoVirksomheter(userInfo.digisyfoOrganisasjoner);
         setAlleRefusjonsstatus(userInfo.refusjoner);
         amplitude.setUserProperties({ syfotilgang: userInfo.digisyfoOrganisasjoner.length > 0 });
-    }, [JSON.stringify(userInfo)]);
+    }, [userInfo]);
 
     const beregnOrganisasjonerArgs = [
         altinnorganisasjoner,


### PR DESCRIPTION
Spinner ved lasting vises allerede i `LoginBoundary`. Hvis vi ikke får userInfo, så har vi ingen ting å vise, så trenger egentlig ikke noe fallback-verdi.

Ytterligere refactoring følger.

- [x] test i dev