### PR TITLE
Skru på autologin i wonderwall

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
     <head>
         <title>Min side – Arbeidsgiver</title>
         <meta charset="utf-8" />
-        <link rel="prefetch" href="/min-side-arbeidsgiver/api/userInfo/v1" as="fetch" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
         <meta

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -27,6 +27,7 @@ spec:
     enabled: true
     sidecar:
       enabled: true
+      autoLogin: true
   envFrom:
     - secret: min-side-ag-frontend
   env:

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -27,6 +27,7 @@ spec:
     enabled: true
     sidecar:
       enabled: true
+      autoLogin: true
   envFrom:
     - secret: min-side-ag-frontend
   env:


### PR DESCRIPTION
For topnivå-dokuement-kall (~index.html), så returneres 302 med redirect til idporten hvis token er utløpt eller mangler. https://doc.nais.io/addons/wonderwall/#12-autologin

- CSS/JS/osv ligger på cdn, og blir ikke påvirket av dette.
- Vil i praksis kun treffer kallet for index.html
- Ikke erstatning for auth/z.

- [x] test dev