### PR TITLE
no store cache control og fjern andre konflikterende verdier

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -356,9 +356,7 @@ const main = async () => {
     });
 
     app.get('/min-side-arbeidsgiver/*', (req, res) => {
-        res.setHeader('Surrogate-Control', 'no-store');
-        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-        res.setHeader('Expires', '0');
+        res.setHeader('Cache-Control', 'no-store');
         res.setHeader('Etag', GIT_COMMIT);
         res.send(indexHtml);
     });


### PR DESCRIPTION
Det jeg lånte fra helmetjs/nocache ser ikke ut til å gi mening.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-cache

> If you want caches to always check for content updates while reusing stored content, no-cache is the directive to use. It does this by requiring caches to revalidate each request with the origin server.
Note that no-cache does not mean "don't cache". no-cache allows caches to store a response but requires them to revalidate it before reuse. If the sense of "don't cache" that you want is actually "don't store", then no-store is the directive to use.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-store
> The no-store response directive indicates that any caches of any kind (private or shared) should not store this response.