### PR TITLE
Revert "set strict-origin referrer policy"

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
         <meta property="og:url" content="https://arbeidsgiver.nav.no/min-side-arbeidsgiver" />
         <meta name="format-detection" content="telephone=no" />
         <meta name="theme-color" content="#000000" />
-        <meta name="referrer" content="strict-origin" />
     </head>
 
     <body>


### PR DESCRIPTION
Reverts navikt/min-side-arbeidsgiver#1747

Jeg er litt redd for at redirect-til-login nå er broken. Sliter med å få testet det, men koden gjør en redirect til referrer, så det kan neppe fungere lenger:

```
        app.get('/min-side-arbeidsgiver/redirect-til-login', (req, res) => {
            const target = new URL(LOGIN_URL);
            target.searchParams.set('redirect', req.get('referer'));
            res.redirect(target.href);
        });
```