### PR TITLE
Sjekker at saksoversikt er i url

### DIFF
--- a/src/Pages/Saksoversikt/useOversiktSessionStorage.ts
+++ b/src/Pages/Saksoversikt/useOversiktSessionStorage.ts
@@ -131,10 +131,14 @@ export const useSessionStateOversikt = (alleVirksomheter: Organisasjon[]): UseSe
     );
 
     const [sessionState, setSessionState] = useState<SessionStateSaksoversikt>(() => {
-        try {
-            return FilterFromSessionState.parse(sessionStorage);
-        } catch (e) {
-            console.error('#MSA: Parse av filter fra SessionStorage feilet', e);
+        if (sessionStorage.route === '/saksoversikt') {
+            try {
+                return FilterFromSessionState.parse(sessionStorage);
+            } catch (e) {
+                console.error('#MSA: Parse av filter fra SessionStorage feilet', e);
+                return defaultSessionState;
+            }
+        } else {
             return defaultSessionState;
         }
     });


### PR DESCRIPTION
Zod.parse kastet feil i useSessionStateOversikt fordi den parset sessionStorage.route til "/saksoversikt". Dersom dette ikke var url, så kastet den feil. Dette skjer når man går inn i saksoversikten fra forsiden.