### PR TITLE
legg til måling av tjenestebokser vist og juster tilgangskombinasjon til å omfatte alle tilganger

### DIFF
--- a/src/altinn/tjenester.ts
+++ b/src/altinn/tjenester.ts
@@ -7,19 +7,21 @@ export type AltinnskjemaId =
     | 'utsendtArbeidstakerEØS'
     | 'endreBankkontonummerForRefusjoner';
 
-export type NAVtjenesteId =
-    | 'arbeidstrening'
-    | 'arbeidsforhold'
-    | 'midlertidigLønnstilskudd'
-    | 'varigLønnstilskudd'
-    | 'sommerjobb'
-    | 'mentortilskudd'
-    | 'inkluderingstilskudd'
-    | 'sykefravarstatistikk'
-    | 'forebyggefravar'
-    | 'rekruttering'
-    | 'tilskuddsbrev'
-    | 'yrkesskade';
+export const NAVtjenesteId = [
+    'arbeidstrening',
+    'arbeidsforhold',
+    'midlertidigLønnstilskudd',
+    'varigLønnstilskudd',
+    'sommerjobb',
+    'mentortilskudd',
+    'inkluderingstilskudd',
+    'sykefravarstatistikk',
+    'forebyggefravar',
+    'rekruttering',
+    'tilskuddsbrev',
+    'yrkesskade',
+];
+export type NAVtjenesteId = (typeof NAVtjenesteId)[number];
 
 export interface AltinnFellesInfo {
     navn: string;

--- a/src/utils/funksjonerForAmplitudeLogging.ts
+++ b/src/utils/funksjonerForAmplitudeLogging.ts
@@ -3,6 +3,7 @@ import { OrganisasjonInfo } from '../Pages/OrganisasjonerOgTilgangerProvider';
 import { Hovedenhet, useUnderenhet } from '../api/enhetsregisteretApi';
 import { useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
+import { NAVtjenesteId } from '../altinn/tjenester';
 
 interface EventProps {
     url: string;
@@ -70,30 +71,20 @@ export const useLoggBedriftValgtOgTilganger = (org: OrganisasjonInfo | undefined
         if (org === undefined) return;
         if (isLoading) return;
 
-        let tilgangskombinasjon = '';
+        const navtjenestetilganger = Object.entries(org.altinntilgang)
+            .filter(([key, value]) => key in NAVtjenesteId && value === true)
+            .map(([key]) => key);
 
-        if (org.altinntilgang.rekruttering) {
-            tilgangskombinasjon += 'arbeidsplassen ';
-        }
-        if (org.altinntilgang.sykefravarstatistikk) {
-            tilgangskombinasjon += 'sykefraværsstatistikk ';
-        }
-        if (org.altinntilgang.arbeidstrening) {
-            tilgangskombinasjon += 'arbeidstrening ';
-        }
-        if (org.altinntilgang.arbeidsforhold) {
-            tilgangskombinasjon += 'arbeidsforhold';
-        }
-        if (org.altinntilgang.midlertidigLønnstilskudd) {
-            tilgangskombinasjon += 'midlertidig lønnstilskudd ';
-        }
-        if (org.altinntilgang.varigLønnstilskudd) {
-            tilgangskombinasjon += 'varig lønnstilskudd';
-        }
+        const tilgangskombinasjonArr = [
+            ...navtjenestetilganger,
+            org.syfotilgang ? 'syfo-nærmesteleder' : null,
+        ].filter((e) => e);
+        const tilgangskombinasjon = tilgangskombinasjonArr.toSorted().join(' ');
 
         const virksomhetsinfo: any = {
             url: baseUrl,
             tilgangskombinasjon,
+            tilgangskombinasjonArr,
             organisasjonstypeForØversteLedd: org.organisasjonstypeForØversteLedd,
         };
 


### PR DESCRIPTION
Skrev om tilgangskombinasjon slik at den får med alle tjenester. La også til syfo-nærmesteleder.
La til måling av hvilke tjenestebokser som vises til brukeren.

Tilgangskombinasjon var en tekststreng, mulig det er pga noe begrensninger i amplitude.
La til en ny prop ved siden av for å teste ut om vi får til det samme uten å ha de som en tekststreng i kallet til amplitude.