### PR TITLE
litt mer pessmistisk get storage

### DIFF
--- a/src/api/storageApi.ts
+++ b/src/api/storageApi.ts
@@ -16,15 +16,23 @@ export async function getStorage(key: string): Promise<StorageItemResponse> {
                     version: respons.headers.get('version'),
                 },
             };
+        } else if (respons.ok) {
+            const jsonResult = await respons.json();
+            return {
+                loadedStorageItem: {
+                    key,
+                    data: jsonResult,
+                    version: respons.headers.get('version'),
+                },
+            };
+        } else {
+            return {
+                error: {
+                    status: respons.status,
+                    statusText: respons.statusText,
+                },
+            };
         }
-        const jsonResult = await respons.json();
-        return {
-            loadedStorageItem: {
-                key,
-                data: jsonResult,
-                version: respons.headers.get('version'),
-            },
-        };
     } catch (error) {
         return { error };
     }


### PR DESCRIPTION
kan virke som vi av og til får d.map not a function på kall som går etter session er ugyldig. Da vil kallet til backend returnere 401 med en json body, som her blir forsøkt parset