### PR TITLE
kombinasjoner krever event logget som en string

### DIFF
--- a/src/Pages/Hovedside/Tjenestebokser/Tjenestebokser.tsx
+++ b/src/Pages/Hovedside/Tjenestebokser/Tjenestebokser.tsx
@@ -75,7 +75,7 @@ const Tjenestebokser: FunctionComponent<{ tjenester: TjenesteBoks[] }> = ({ tjen
     useEffect(() => {
         amplitude.logEvent('komponent-lastet', {
             komponent: 'tjenestebokser',
-            tjenester: tjenester.toSorted(),
+            tjenester: tjenester.toSorted().join(' '),
         });
     }, []);
 

--- a/src/utils/funksjonerForAmplitudeLogging.ts
+++ b/src/utils/funksjonerForAmplitudeLogging.ts
@@ -75,16 +75,17 @@ export const useLoggBedriftValgtOgTilganger = (org: OrganisasjonInfo | undefined
             .filter(([key, value]) => key in NAVtjenesteId && value === true)
             .map(([key]) => key);
 
-        const tilgangskombinasjonArr = [
+        const tilgangskombinasjon = [
             ...navtjenestetilganger,
             org.syfotilgang ? 'syfo-nærmesteleder' : null,
-        ].filter((e) => e);
-        const tilgangskombinasjon = tilgangskombinasjonArr.toSorted().join(' ');
+        ]
+            .filter((e) => e)
+            .toSorted()
+            .join(' ');
 
         const virksomhetsinfo: any = {
             url: baseUrl,
             tilgangskombinasjon,
-            tilgangskombinasjonArr,
             organisasjonstypeForØversteLedd: org.organisasjonstypeForØversteLedd,
         };
 


### PR DESCRIPTION
Fant ikke dette i dokumentasjonen, men i [en tråd](https://community.amplitude.com/data-instrumentation-57/use-eventing-to-track-possible-permutations-for-items-in-a-custom-list-1055?postid=3618#post3618) på support sidene blir det nevnt at amplitude ser hver verdi fra en liste i isolasjon. Så hvis man ønsker å ha måling på kombinsjoner må man lage det som en streng.