### PR TITLE
koble tilgangssøknader fra tilganger fra backend

### DIFF
--- a/src/Pages/OrganisasjonerOgTilgangerProvider.tsx
+++ b/src/Pages/OrganisasjonerOgTilgangerProvider.tsx
@@ -62,7 +62,7 @@ const useBeregnAltinnTilgangssøknad = ():
             userInfo.organisasjoner.map((org) => {
                 return [
                     org.OrganizationNumber,
-                    Record.map(userInfo.tilganger, (id: AltinntjenesteId) =>
+                    Record.map(altinntjeneste, (id: AltinntjenesteId) =>
                         sjekkTilgangssøknader(org.OrganizationNumber, id, altinnTilgangssøknader)
                     ),
                 ];


### PR DESCRIPTION
uten denne endringen krever det at vi returnerer en liste av alle tilganger fra backend, ikke bare de man har tilgang til.
Med denne endringen så vil vi ikke være avhengig av en liste av alle mulige tilganger fra backend, men lene oss på de frontend bryr seg om å vise.