### PR TITLE
Legg til støtte for kalenderavtale avholdt

### DIFF
--- a/bruker.graphql
+++ b/bruker.graphql
@@ -218,6 +218,7 @@ enum KalenderavtaleTilstand {
     ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED
     ARBEIDSGIVER_HAR_GODTATT
     AVLYST
+    AVHOLDT
 }
 
 type Virksomhet {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@faker-js/faker": "8.4.1",
         "@grafana/faro-web-sdk": "1.3.6",
         "@navikt/aksel-icons": "^5.17.2",
-        "@navikt/arbeidsgiver-notifikasjon-widget": "7.2.1",
+        "@navikt/arbeidsgiver-notifikasjon-widget": "7.2.2-0",
         "@navikt/bedriftsmeny": "7.0.5",
         "@navikt/ds-css": "^6.15.0",
         "@navikt/ds-icons": "3.4.3",
@@ -5094,9 +5094,9 @@
       "license": "MIT"
     },
     "node_modules/@navikt/arbeidsgiver-notifikasjon-widget": {
-      "version": "7.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsgiver-notifikasjon-widget/7.2.1/9a2bad6d7448a35c2c6a8c15239450f97b4132cf",
-      "integrity": "sha512-6jCsrkt0KPa7sw6UpSEA36tdZ9zcsD/KY3cB9tqvKmSdx5Dl/aJQTUR1+NJ5GEaBlaQHomzjm8H878KljG0egQ==",
+      "version": "7.2.2-0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/arbeidsgiver-notifikasjon-widget/7.2.2-0/182a840405545063bca64e24ac665fa0cc680292",
+      "integrity": "sha512-UQI658TcR3SvvV9cxFfzsyd8IWiNixMNvWe8M8766gy2mjx5GTn+nCsiP+fNXCkYS2KBryRVGikPrfmNenEG3w==",
       "dependencies": {
         "@apollo/client": "^3.10.8",
         "graphql": "^16.9.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@faker-js/faker": "8.4.1",
     "@grafana/faro-web-sdk": "1.3.6",
     "@navikt/aksel-icons": "^5.17.2",
-    "@navikt/arbeidsgiver-notifikasjon-widget": "7.2.1",
+    "@navikt/arbeidsgiver-notifikasjon-widget": "7.2.2-0",
     "@navikt/bedriftsmeny": "7.0.5",
     "@navikt/ds-css": "^6.15.0",
     "@navikt/ds-icons": "3.4.3",

--- a/src/GeneriskeElementer/StatusLinje.tsx
+++ b/src/GeneriskeElementer/StatusLinje.tsx
@@ -177,6 +177,13 @@ export const AvtaletilstandLinje = ({
                 </Tag>
             );
 
+        case KalenderavtaleTilstand.Avholdt:
+            return (
+                <Tag size="small" className="tidslinje_kalenderavtale_status_text" variant="info">
+                    Avholdt
+                </Tag>
+            );
+
         default:
             return null;
     }

--- a/src/Pages/Hovedside/Kalenderavtaler.tsx
+++ b/src/Pages/Hovedside/Kalenderavtaler.tsx
@@ -207,6 +207,12 @@ const Statustag = ({ tilstand }: Statustag) => {
                     Møtet er avlyst
                 </Tag>
             );
+        case KalenderavtaleTilstand.Avholdt:
+            return (
+                <Tag size="small" variant="error-moderate">
+                    Møtet er avholdt
+                </Tag>
+            );
         default:
             return null;
     }

--- a/src/Pages/Saksoversikt/SakPanel.tsx
+++ b/src/Pages/Saksoversikt/SakPanel.tsx
@@ -426,7 +426,7 @@ const KalenderavtaleElement = ({
                 >
                     {dateFormat.format(new Date(startTidspunkt))} kl.{' '}
                     {klokkeslett.format(new Date(startTidspunkt))}
-                    {sluttTidspunkt !== undefined
+                    {sluttTidspunkt !== undefined && sluttTidspunkt !== null
                         ? ` – ${klokkeslett.format(new Date(sluttTidspunkt))}`
                         : ''}
                 </BodyShort>

--- a/src/Pages/Saksoversikt/SakPanel.tsx
+++ b/src/Pages/Saksoversikt/SakPanel.tsx
@@ -70,7 +70,9 @@ export const SakPanel = ({
                 </Tag>
             </div>
             <Saksoverskrift lenkeTilSak={lenkeTilSak} sak={sak} />
-            {sak.tilleggsinformasjon !== null ? <BodyShort>{sak.tilleggsinformasjon}</BodyShort> : null}
+            {sak.tilleggsinformasjon !== null ? (
+                <BodyShort>{sak.tilleggsinformasjon}</BodyShort>
+            ) : null}
             <div style={{ display: 'flex', gap: '16px' }}>
                 <BodyShort size="small" style={style}>
                     <strong>{sak.sisteStatus.tekst}</strong>
@@ -232,6 +234,7 @@ const Tidslinje = ({ sak, tvingEkspander }: TidslinjeProps) => {
                     <>
                         {todos.map((tidslinjeelement, i) => (
                             <Tidslinjeelement
+                                key={tidslinjeelement.id}
                                 tidslinjeelement={tidslinjeelement}
                                 skjulLinjeIkon={false}
                                 brukDelvisStipletLinjeIkon={true}
@@ -241,6 +244,7 @@ const Tidslinje = ({ sak, tvingEkspander }: TidslinjeProps) => {
                             const erSist = sak.tidslinje.length - 1;
                             return (
                                 <Tidslinjeelement
+                                    key={tidslinjeelement.id}
                                     tidslinjeelement={tidslinjeelement}
                                     skjulLinjeIkon={i === erSist}
                                     brukDelvisStipletLinjeIkon={!tidslinjeOpen}
@@ -380,12 +384,13 @@ const KalenderavtaleElement = ({
     return (
         <div className={ingenLokasjon ? 'grid2x3' : 'grid2x4'}>
             <div className="tidslinje-element-ikon">
-                {avtaletilstand === KalenderavtaleTilstand.Avlyst || harPassert ? (
+                {avtaletilstand === KalenderavtaleTilstand.Avlyst ||
+                avtaletilstand === KalenderavtaleTilstand.Avholdt ? (
                     <KalenderavtaleIkon
                         variant="grå"
                         title={
                             harPassert
-                                ? 'Kalenderavtale som har passert.'
+                                ? 'Kalenderavtale som er avholdt.'
                                 : 'Kalenderavtale som er avlyst.'
                         }
                     />
@@ -409,7 +414,17 @@ const KalenderavtaleElement = ({
                             : 'regular'
                     }
                 >
-                    {tekst} {dateFormat.format(new Date(startTidspunkt))} kl.{' '}
+                    {tekst}
+                </BodyShort>
+                <BodyShort
+                    size="large"
+                    weight={
+                        avtaletilstand === KalenderavtaleTilstand.VenterSvarFraArbeidsgiver
+                            ? 'semibold'
+                            : 'regular'
+                    }
+                >
+                    {dateFormat.format(new Date(startTidspunkt))} kl.{' '}
                     {klokkeslett.format(new Date(startTidspunkt))}
                     {sluttTidspunkt !== undefined
                         ? ` – ${klokkeslett.format(new Date(sluttTidspunkt))}`

--- a/src/Pages/Saksoversikt/Saksfilter/Saksfilter.tsx
+++ b/src/Pages/Saksoversikt/Saksfilter/Saksfilter.tsx
@@ -127,7 +127,6 @@ const InntektsmeldingGruppe = (
         navn.includes('Inntektsmelding')
     );
 
-
     if (inntektsmeldingAlleValgtAvBruker) {
         valgteInntektsmeldingtyper = ['Inntektsmelding_gruppe'];
     } else if (andreInntektsmeldingerValgt) {
@@ -172,6 +171,7 @@ const InntektsmeldingGruppe = (
 
     return (
         <CheckboxGroup
+            key="Inntektsmelding_gruppe"
             legend={'Inntektsmeldinger'}
             hideLegend={true}
             value={valgteInntektsmeldingtyper}

--- a/src/api/graphql-types.ts
+++ b/src/api/graphql-types.ts
@@ -76,6 +76,7 @@ export enum KalenderavtaleTilstand {
   ArbeidsgiverHarGodtatt = 'ARBEIDSGIVER_HAR_GODTATT',
   ArbeidsgiverVilAvlyse = 'ARBEIDSGIVER_VIL_AVLYSE',
   ArbeidsgiverVilEndreTidEllerSted = 'ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED',
+  Avholdt = 'AVHOLDT',
   Avlyst = 'AVLYST',
   VenterSvarFraArbeidsgiver = 'VENTER_SVAR_FRA_ARBEIDSGIVER'
 }

--- a/src/mocks/brukerApi/alleKalenderavtaler.ts
+++ b/src/mocks/brukerApi/alleKalenderavtaler.ts
@@ -6,7 +6,6 @@ export const alleKalenderavtaler = [
     kalenderavtale({
         tekst: `Dialogmøte ${fakeName()}`,
         startTidspunkt: dateInPast({ days: 1, hours: 1 }),
-        sluttTidspunkt: dateInPast({ days: 1 }),
         avtaletilstand: KalenderavtaleTilstand.Avholdt,
         lokasjon: {
             adresse: faker.location.streetAddress(),

--- a/src/mocks/brukerApi/alleKalenderavtaler.ts
+++ b/src/mocks/brukerApi/alleKalenderavtaler.ts
@@ -1,8 +1,21 @@
 import { KalenderavtaleTilstand } from '../../api/graphql-types';
 import { fakerNB_NO as faker } from '@faker-js/faker';
-import { dateInFuture, fakeName, kalenderavtale } from './helpers';
+import { dateInFuture, dateInPast, fakeName, kalenderavtale } from './helpers';
 
 export const alleKalenderavtaler = [
+    kalenderavtale({
+        tekst: `Dialogmøte ${fakeName()}`,
+        startTidspunkt: dateInPast({ days: 1, hours: 1 }),
+        sluttTidspunkt: dateInPast({ days: 1 }),
+        avtaletilstand: KalenderavtaleTilstand.Avholdt,
+        lokasjon: {
+            adresse: faker.location.streetAddress(),
+            postnummer: faker.location.zipCode('####'),
+            poststed: faker.location.city(),
+        },
+        digitalt: true,
+        merkelapp: 'Dialogmøte',
+    }),
     kalenderavtale({
         tekst: `Dialogmøte ${fakeName()}`,
         startTidspunkt: dateInFuture({ days: 1 }),

--- a/src/mocks/brukerApi/alleSaker.ts
+++ b/src/mocks/brukerApi/alleSaker.ts
@@ -251,8 +251,19 @@ export const alleSaker = [
             }),
             kalenderavtaleTidslinjeElement({
                 tekst: 'Invitasjon til dialogmøte',
-                avtaletilstand: KalenderavtaleTilstand.Avlyst,
+                avtaletilstand: KalenderavtaleTilstand.ArbeidsgiverHarGodtatt,
+                startTidspunkt: dateInPast({ days: 2 }),
                 lokasjon: undefined,
+                digitalt: true,
+            }),
+            kalenderavtaleTidslinjeElement({
+                tekst: 'Invitasjon til dialogmøte',
+                avtaletilstand: KalenderavtaleTilstand.Avholdt,
+                lokasjon: {
+                    adresse: 'Sørkedalsveien 31',
+                    postnummer: '0788',
+                    poststed: 'Sandnes',
+                },
                 digitalt: false,
             }),
         ],

--- a/src/mocks/brukerApi/helpers.ts
+++ b/src/mocks/brukerApi/helpers.ts
@@ -195,14 +195,14 @@ export const beskjed = ({
     opprettetTidspunkt = faker.date.recent(),
     klikketPaa = true,
     tilleggsinformasjon,
-    lenke =  `#${faker.lorem.word()}`,
+    lenke = `#${faker.lorem.word()}`,
 }: {
     tekst: string;
     sakTittel?: string;
     opprettetTidspunkt?: Date;
     klikketPaa?: boolean;
     tilleggsinformasjon?: string;
-    lenke?: string,
+    lenke?: string;
 }): Beskjed => ({
     __typename: 'Beskjed',
     id: faker.string.uuid(),
@@ -340,9 +340,10 @@ export const executeAndValidate = ({
         rootValue,
     });
 
-export const dateInPast = ({ days = 0, years = 0, months = 0 }) => {
+export const dateInPast = ({ hours = 0, days = 0, years = 0, months = 0 }) => {
     const date = new Date();
     date.setDate(date.getDate() - days);
+    date.setHours(date.getHours() - hours);
     date.setFullYear(date.getFullYear() - years);
     date.setMonth(date.getMonth() - months);
     return date;


### PR DESCRIPTION
lagt til i tidslinje på sak og kommende kalenderavtaler. På kommende kalenderavtaler vil det ikke vises da det filtreres i backend, men koden i frondend støtter det nå uansett. Widget er oppdatert til versjon som støtter avholdt også.

* widget
![image](https://github.com/user-attachments/assets/f78cc702-d709-42be-b66a-53dd220ffd6e)
* tidslinje på sak
![image](https://github.com/user-attachments/assets/b614a6da-44ad-4335-8fd7-47a107db26c0)
* kommende kalenderavtale (denne vil nok aldri egentlig vises pga filtrering i backend)
![image](https://github.com/user-attachments/assets/1a05a93e-5e08-431e-b146-09a597d4c9a4)

