### PR TITLE
fiks init valgt org bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@navikt/ds-icons": "3.4.3",
         "@navikt/ds-react": "^6.15.0",
         "@navikt/nav-dekoratoren-moduler": "3.1.1",
-        "@navikt/virksomhetsvelger": "0.0.18",
+        "@navikt/virksomhetsvelger": "0.1.0",
         "fuzzysort": "^1.1.4",
         "immutable": "^4.3.6",
         "msw": "2.3.1",
@@ -5341,9 +5341,9 @@
       }
     },
     "node_modules/@navikt/virksomhetsvelger": {
-      "version": "0.0.18",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/virksomhetsvelger/0.0.18/57e20e29875267383709e941306eb91400f8a51f",
-      "integrity": "sha512-HbUVL/AshxYkN8lm5YM6EfVRL8bHlaAPJd8FeFP4sP3hHgF1aUjQceWnNChErTojKikQUQR6vwVFYWUROviRUg==",
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/virksomhetsvelger/0.1.0/0de24b60f97a3b512b722ce71e7fc0b0e49ba327",
+      "integrity": "sha512-ChFnehHgNlJDXeDYzq4PnzSUBMc4OeLSXLoZd43yYWVv7u2GKi++3QUYRabnx/SpF6m1fbgDWSr5rAT+w+MdTA==",
       "dependencies": {
         "focus-trap-react": "10.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@navikt/ds-icons": "3.4.3",
     "@navikt/ds-react": "^6.15.0",
     "@navikt/nav-dekoratoren-moduler": "3.1.1",
-    "@navikt/virksomhetsvelger": "0.0.18",
+    "@navikt/virksomhetsvelger": "0.1.0",
     "fuzzysort": "^1.1.4",
     "immutable": "^4.3.6",
     "msw": "2.3.1",

--- a/src/Pages/Banner.tsx
+++ b/src/Pages/Banner.tsx
@@ -28,7 +28,7 @@ export const BannerMedBedriftsmeny: FunctionComponent<{
     sidetittel: string;
 }> = ({ sidetittel }) => {
     const { organisasjonstre } = useOrganisasjonerOgTilgangerContext();
-    const { endreOrganisasjon } = useOrganisasjonsDetaljerContext();
+    const { endreOrganisasjon, valgtOrganisasjon } = useOrganisasjonsDetaljerContext();
 
     const [params, setParams] = useSearchParams();
     const orgnrFraUrl = params.get('bedrift');
@@ -47,7 +47,11 @@ export const BannerMedBedriftsmeny: FunctionComponent<{
 
     return (
         <Banner tittel={sidetittel}>
-            <Virksomhetsvelger organisasjoner={organisasjonstre} onChange={endreOrganisasjon} />
+            <Virksomhetsvelger
+                organisasjoner={organisasjonstre}
+                onChange={endreOrganisasjon}
+                initValgtOrgnr={valgtOrganisasjon.organisasjon.orgnr}
+            />
             <NotifikasjonWidget />
         </Banner>
     );

--- a/src/Pages/OrganisasjonerOgTilgangerContext.ts
+++ b/src/Pages/OrganisasjonerOgTilgangerContext.ts
@@ -233,7 +233,6 @@ export const useBeregnOrganisasjonstre = (): { organisasjonstre: Organisasjon[] 
             return { organisasjonstre: [] };
         }
 
-        // TODO: naive implementation, perhaps need to deep check for duplicates
         const organisasjonstre: Organisasjon[] = mergeOrgTre(
             userInfo.organisasjoner,
             mapRecursive<Organisasjon>(userInfo.digisyfoOrganisasjoner, (org) => ({

--- a/src/Pages/OrganisasjonsDetaljerProvider.tsx
+++ b/src/Pages/OrganisasjonsDetaljerProvider.tsx
@@ -45,7 +45,7 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<{
     }, [data, loading]);
 
     const endreOrganisasjon = (org: Organisasjon) => {
-        sessionStorage.setItem(VALGT_ORG_STORAGE, org.orgnr);
+        localStorage.setItem(VALGT_ORG_STORAGE, org.orgnr);
         setValgtOrganisasjon(organisasjonsInfo[org.orgnr]);
     };
 

--- a/src/Pages/OrganisasjonsDetaljerProvider.tsx
+++ b/src/Pages/OrganisasjonsDetaljerProvider.tsx
@@ -16,12 +16,13 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<{
 }> = ({ children }: { children: React.ReactNode }) => {
     const { organisasjonsInfo } = useOrganisasjonerOgTilgangerContext();
     const [valgtOrganisasjon, setValgtOrganisasjon] = useState<OrganisasjonInfo>(() => {
-        const sessionOrg = organisasjonsInfo[localStorage.getItem(VALGT_ORG_STORAGE) ?? ''];
-        const tilfeldigVirksomhet = Object.values(organisasjonsInfo).find(
-            (o) => o.parent !== undefined && o.organisasjon.underenheter.length === 0
+        const lagretOrg = organisasjonsInfo[localStorage.getItem(VALGT_ORG_STORAGE) ?? ''];
+        return (
+            lagretOrg ??
+            Object.values(organisasjonsInfo).find(
+                (o) => o.parent !== undefined && o.organisasjon.underenheter.length === 0
+            )
         );
-
-        return sessionOrg ?? tilfeldigVirksomhet;
     });
 
     const [antallSakerForAlleBedrifter, setAntallSakerForAlleBedrifter] = useState<

--- a/src/Pages/OrganisasjonsDetaljerProvider.tsx
+++ b/src/Pages/OrganisasjonsDetaljerProvider.tsx
@@ -10,17 +10,18 @@ import {
     useOrganisasjonerOgTilgangerContext,
 } from './OrganisasjonerOgTilgangerContext';
 
+const VALGT_ORG_STORAGE = 'virksomhetsvelger_bedrift';
 export const OrganisasjonsDetaljerProvider: FunctionComponent<{
     children: React.ReactNode;
 }> = ({ children }: { children: React.ReactNode }) => {
     const { organisasjonsInfo } = useOrganisasjonerOgTilgangerContext();
     const [valgtOrganisasjon, setValgtOrganisasjon] = useState<OrganisasjonInfo>(() => {
-        const sessionVirksomhet = organisasjonsInfo[sessionStorage.getItem('bedrift') ?? ''];
+        const sessionOrg = organisasjonsInfo[localStorage.getItem(VALGT_ORG_STORAGE) ?? ''];
         const tilfeldigVirksomhet = Object.values(organisasjonsInfo).find(
             (o) => o.parent !== undefined && o.organisasjon.underenheter.length === 0
         );
 
-        return sessionVirksomhet ?? tilfeldigVirksomhet;
+        return sessionOrg ?? tilfeldigVirksomhet;
     });
 
     const [antallSakerForAlleBedrifter, setAntallSakerForAlleBedrifter] = useState<
@@ -44,6 +45,7 @@ export const OrganisasjonsDetaljerProvider: FunctionComponent<{
     }, [data, loading]);
 
     const endreOrganisasjon = (org: Organisasjon) => {
+        sessionStorage.setItem(VALGT_ORG_STORAGE, org.orgnr);
         setValgtOrganisasjon(organisasjonsInfo[org.orgnr]);
     };
 

--- a/src/Pages/OrganisasjonsDetaljerProvider.tsx
+++ b/src/Pages/OrganisasjonsDetaljerProvider.tsx
@@ -13,11 +13,14 @@ import {
 export const OrganisasjonsDetaljerProvider: FunctionComponent<{
     children: React.ReactNode;
 }> = ({ children }: { children: React.ReactNode }) => {
-    const { organisasjonsInfo, organisasjonerFlatt } = useOrganisasjonerOgTilgangerContext();
+    const { organisasjonsInfo } = useOrganisasjonerOgTilgangerContext();
     const [valgtOrganisasjon, setValgtOrganisasjon] = useState<OrganisasjonInfo>(() => {
-        const førsteVirksomhet = organisasjonerFlatt.find((it) => it.underenheter.length === 0);
-        const lagretVirksomhetOrgnr = sessionStorage.getItem('bedrift');
-        return organisasjonsInfo[lagretVirksomhetOrgnr ?? førsteVirksomhet?.orgnr ?? ''];
+        const sessionVirksomhet = organisasjonsInfo[sessionStorage.getItem('bedrift') ?? ''];
+        const tilfeldigVirksomhet = Object.values(organisasjonsInfo).find(
+            (o) => o.parent !== undefined && o.organisasjon.underenheter.length === 0
+        );
+
+        return sessionVirksomhet ?? tilfeldigVirksomhet;
     });
 
     const [antallSakerForAlleBedrifter, setAntallSakerForAlleBedrifter] = useState<

--- a/src/mocks/handlers/eregHandlers.ts
+++ b/src/mocks/handlers/eregHandlers.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from 'msw';
-import { orgnr } from '../brukerApi/helpers';
 import { faker } from '@faker-js/faker';
 import { Demoprofil } from '../../hooks/useDemoprofil';
 import { dagligLederOrganisasjon } from '../scenarios/dagligLederScenario';
 import { nærmesteLederOrganisasjon } from '../scenarios/nærmesteLederScenario';
 import { regnskapsforerOrganisasjoner } from '../scenarios/regnskapsforerScenario';
+import { findRecursive } from '@navikt/virksomhetsvelger';
 
 type organisasjon = {
     orgnr: string;
@@ -21,12 +21,12 @@ const organisasjoner: {
     Regnskapsforer: regnskapsforerOrganisasjoner,
 };
 
-const parentOrgnr = (demoprofil: Demoprofil, underenhetOrgnr: string | readonly string[]) => {
-    const org = organisasjoner[demoprofil].find((o) =>
+const parentOrgnr = (demoprofil: Demoprofil, underenhetOrgnr: string) => {
+    const org = findRecursive(organisasjoner[demoprofil], (o) =>
         o.underenheter.some((u) => u.orgnr === underenhetOrgnr)
     );
     if (!org) {
-        throw new Error(`Fant ikke organisasjon med orgnr ${orgnr}`);
+        throw new Error(`Fant ikke organisasjon med orgnr ${underenhetOrgnr}`);
     }
     return org.orgnr;
 };

--- a/src/mocks/scenarios/dagligLederScenario.ts
+++ b/src/mocks/scenarios/dagligLederScenario.ts
@@ -75,16 +75,28 @@ export const dagligLederOrganisasjon = {
     organisasjonsform: 'AS',
     underenheter: [...underenheter.slice(1), orgledd],
 };
+const hestemannen = {
+    orgnr: '994884344',
+    organisasjonsform: 'FLI',
+    navn: 'HESTMANNEN UNGDOMS- OG IDRETTSLAG',
+    altinn3Tilganger: [],
+    altinn2Tilganger: [],
+    underenheter: [],
+};
 
 export const dagligLederScenario = [
     http.get('/min-side-arbeidsgiver/api/userInfo/v3', () => {
         return HttpResponse.json({
             altinnError: false,
-            organisasjoner: [dagligLederOrganisasjon],
+            organisasjoner: [hestemannen, dagligLederOrganisasjon],
             tilganger: fromEntries(
                 alleTilganger.map((tilgang) => [
                     tilgang,
-                    [dagligLederOrganisasjon.orgnr, ...underenheter.map((org) => org.orgnr)],
+                    [
+                        '994884344',
+                        dagligLederOrganisasjon.orgnr,
+                        ...underenheter.map((org) => org.orgnr),
+                    ],
                 ])
             ),
             digisyfoError: false,


### PR DESCRIPTION
fikser en bug hvor init state på valgtOrganisasjon noen ganger valgte virksomhet man ikke egentlig kan velge. Eks FLI uten parent eller underenheter. For at en virksomhet skal kunne være "velgbar" så må den være en løvnode, mao være en underenhet og ikke selv ha underenheter.

ref tråd i slack: https://nav-it.slack.com/archives/CCNAY9FGF/p1739524896634519
