### PR TITLE
fiks lagrede filter med verdi som ikke lenger støttes

### DIFF
--- a/src/Pages/Saksoversikt/LagreFilter.tsx
+++ b/src/Pages/Saksoversikt/LagreFilter.tsx
@@ -17,6 +17,7 @@ import { Set } from 'immutable';
 import { v4 as uuidv4 } from 'uuid';
 import { useLoggKlikk } from '../../utils/funksjonerForAmplitudeLogging';
 import './LagreFilter.css';
+import { SakSortering } from '../../api/graphql-types';
 
 export type LagretFilter = {
     uuid: string;
@@ -37,6 +38,13 @@ const statusMapping = {
     error: 'failed',
 } as const;
 
+function fiksSortering(filter: any): SakSortering {
+    if (filter in SakSortering) {
+        return filter;
+    }
+    return SakSortering.NyesteFørst;
+}
+
 const useLagredeFilter = (): {
     lagredeFilter: LagretFilter[];
     lagreNyttLagretFilter: (navn: string, filter: Filter) => LagretFilter;
@@ -53,6 +61,7 @@ const useLagredeFilter = (): {
             filter: {
                 ...filter.filter,
                 virksomheter: Set(filter.filter.virksomheter),
+                sortering: fiksSortering(filter.filter.sortering),
             },
         }))
     );


### PR DESCRIPTION
Jeg tror dette kan være grunnen til at vi ser noen feil i loggene innimellom. 

Her endrer jeg slik at når man laster et lagret filter så validerer vi at den lagrede verdien er støttet. Dersom den ikke er det fallbackes det til "Nyeste"


## Før
![image](https://github.com/user-attachments/assets/73101254-854d-4b3b-abc1-12d32d20a090)

## Etter
![image](https://github.com/user-attachments/assets/96a13577-076c-4e8b-a7b3-d67dfa6ad6fe)
