### PR TITLE
etter 1.mai viser vi infoboks til alle som ser på omvirksomheten siden

### DIFF
--- a/src/Pages/Hovedside/InfoBokser.tsx
+++ b/src/Pages/Hovedside/InfoBokser.tsx
@@ -2,22 +2,13 @@ import React, { FC, useEffect } from 'react';
 import './InfoBokser.css';
 import { gittMiljo } from '../../utils/environment';
 import { shouldDisplay } from '../../GeneriskeElementer/DisplayBetween';
-import { Alert, BodyLong, Heading } from '@navikt/ds-react';
-import { usePrefixedLocalStorage } from '../../hooks/useStorage';
-import { useOrganisasjonsDetaljerContext } from '../OrganisasjonsDetaljerContext';
-import { LenkeMedLogging } from '../../GeneriskeElementer/LenkeMedLogging';
+import { Alert, Heading } from '@navikt/ds-react';
 
 type InfoboksProps = {
     id: string;
     visFra: Date;
     visTil: Date;
     Component: FC<{ id: string }>;
-};
-
-const localStoragePrefix = 'msa-info-boks-';
-const useCloseInfoboks = (id: string) => {
-    const [closed, setClosed] = usePrefixedLocalStorage(id, localStoragePrefix, false);
-    return { closed, setClosed };
 };
 
 const infobokser: Array<InfoboksProps> = [
@@ -37,55 +28,15 @@ const infobokser: Array<InfoboksProps> = [
             );
         },
     },
-    {
-        id: 'endre-kontonummer-11-04-2025',
-        visFra: new Date('2025-04-11T00:00:00+02:00'),
-        visTil: new Date('2025-05-01T00:00:00+02:00'),
-        Component: () => {
-            const { valgtOrganisasjon } = useOrganisasjonsDetaljerContext();
-            const kanEndreKontonummer =
-                valgtOrganisasjon.altinntilgang.endreBankkontonummerForRefusjoner ?? false;
-            if (!kanEndreKontonummer) return;
-            const { closed, setClosed } = useCloseInfoboks('endre-kontonummer-info');
-
-            if (closed) return;
-
-            return (
-                <Alert
-                    variant="info"
-                    contentMaxWidth={false}
-                    closeButton
-                    onClose={() => setClosed(true)}
-                >
-                    <Heading spacing size="small" level="3">
-                        Endringer i tilgang til å endre kontonummer hos NAV
-                    </Heading>
-                    <BodyLong>
-                        Fra 1. mai 2025 strammes reglene inn for hvem som kan endre kontonummer for
-                        refusjoner fra NAV.
-                        <br />
-                        For å gjøre slike endringer, må du ha tilgang til enkelttjenesten: "Endre
-                        bankkontonummer for refusjoner fra NAV til arbeidsgiver". Se
-                        <LenkeMedLogging
-                            href="https://www.nav.no/arbeidsgiver/endring-kontonummer"
-                            loggLenketekst="endring kontonummer"
-                        >
-                            Nytt om tilgang til endring av kontonummer for refusjoner fra Nav.
-                        </LenkeMedLogging>
-                    </BodyLong>
-                </Alert>
-            );
-        },
-    },
 ];
 
-export const InfoBokser = ({ onlyShowIds }: { onlyShowIds?: string[] }) => {
+export const InfoBokser = () => {
     const infobokserSomSkalVises = infobokser.filter(({ id, visFra, visTil }) =>
         shouldDisplay({
             showFrom: visFra,
             showUntil: visTil,
             currentTime: new Date(),
-        }) && (!onlyShowIds || onlyShowIds.includes(id))
+        })
     );
 
     return (

--- a/src/Pages/OmVirksomheten/OmVirksomheten.tsx
+++ b/src/Pages/OmVirksomheten/OmVirksomheten.tsx
@@ -3,13 +3,41 @@ import { useOverordnetEnhet, useUnderenhet } from '../../api/enhetsregisteretApi
 import Underenhet from './Underenhet';
 import OverordnetEnhet from './OverordnetEnhet';
 import './OmVirksomheten.css';
-import { Box } from '@navikt/ds-react';
+import { Alert, BodyLong, Box, Heading } from '@navikt/ds-react';
 import { useOrganisasjonsDetaljerContext } from '../OrganisasjonsDetaljerContext';
-import { InfoBokser } from '../Hovedside/InfoBokser';
+import { LenkeMedLogging } from '../../GeneriskeElementer/LenkeMedLogging';
+import { useCloseInfoboks } from '../../hooks/useCloseInfoboks';
 
 const Kontaktpanel = ({ children }: { children: React.ReactNode }) => (
     <Box className="informasjon-om-bedrift">{children}</Box>
 );
+
+const InfoBoks = () => {
+    const { closed, setClosed } = useCloseInfoboks('endre-kontonummer-info');
+
+    if (closed) return;
+
+    return (
+        <Alert variant="info" contentMaxWidth={false} closeButton onClose={() => setClosed(true)}>
+            <Heading spacing size="small" level="3">
+                Endringer i tilgang til å endre kontonummer hos NAV
+            </Heading>
+            <BodyLong>
+                Fra 1. mai 2025 strammes reglene inn for hvem som kan endre kontonummer for
+                refusjoner fra NAV.
+                <br />
+                For å gjøre slike endringer, må du ha tilgang til enkelttjenesten: "Endre
+                bankkontonummer for refusjoner fra NAV til arbeidsgiver". Se
+                <LenkeMedLogging
+                    href="https://www.nav.no/arbeidsgiver/endring-kontonummer"
+                    loggLenketekst="endring kontonummer"
+                >
+                    Nytt om tilgang til endring av kontonummer for refusjoner fra Nav.
+                </LenkeMedLogging>
+            </BodyLong>
+        </Alert>
+    );
+};
 
 const OmVirksomheten: FunctionComponent = () => {
     const { valgtOrganisasjon } = useOrganisasjonsDetaljerContext();
@@ -24,7 +52,7 @@ const OmVirksomheten: FunctionComponent = () => {
             {overordnetenhet !== undefined && underenhet !== undefined ? (
                 <>
                     <Box className="alert-container">
-                        <InfoBokser onlyShowIds={['endre-kontonummer-11-04-2025']} />
+                        <InfoBoks />
                     </Box>
                     <Kontaktpanel>
                         <Underenhet underenhet={underenhet} />

--- a/src/hooks/useCloseInfoboks.ts
+++ b/src/hooks/useCloseInfoboks.ts
@@ -1,0 +1,7 @@
+import { usePrefixedLocalStorage } from './useStorage';
+
+const localStoragePrefix = 'msa-info-boks-';
+export const useCloseInfoboks = (id: string) => {
+    const [closed, setClosed] = usePrefixedLocalStorage(id, localStoragePrefix, false);
+    return { closed, setClosed };
+};


### PR DESCRIPTION
trekker derfor ut logikk fra infoboks. Kan legge tilbake senere hvis vi trenger det igjen. ingen visfra-til på nye boksen. Den er der til noen lukker den, eller at vi fjerner koden.