### PR TITLE
refactor demodata & resolvers

### DIFF
--- a/src/mocks/scenarios/dagligLederScenario.ts
+++ b/src/mocks/scenarios/dagligLederScenario.ts
@@ -2,17 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { faker } from '@faker-js/faker';
 import { orgnr } from '../brukerApi/helpers';
 import { fromEntries } from '../../utils/Record';
-import {
-    hentKalenderavtalerResolver,
-    hentNotifikasjonerResolver,
-    hentSakerResolver,
-    sakstyperResolver,
-    hentSakByIdResolver,
-} from '../brukerApi/resolvers';
-import { alleSaker } from '../brukerApi/alleSaker';
-import { alleKalenderavtaler } from '../brukerApi/alleKalenderavtaler';
-import { alleNotifikasjoner } from '../brukerApi/alleNotifikasjoner';
-import { Merkelapp } from '../brukerApi/alleMerkelapper';
+import { brukerApiHandlers } from '../brukerApi/resolvers';
 import { mapRecursive } from '../../utils/util';
 
 const alleTilganger = [
@@ -170,9 +160,5 @@ export const dagligLederScenario = [
     ),
 
     // brukerApi
-    hentSakerResolver(alleSaker),
-    sakstyperResolver(alleSaker.map(({ merkelapp }) => merkelapp as Merkelapp)),
-    hentKalenderavtalerResolver(alleKalenderavtaler),
-    hentNotifikasjonerResolver(alleNotifikasjoner),
-    hentSakByIdResolver(alleSaker),
+    ...brukerApiHandlers([dagligLederOrganisasjon], (_) => true),
 ];

--- a/src/mocks/scenarios/nærmesteLederScenario.ts
+++ b/src/mocks/scenarios/nærmesteLederScenario.ts
@@ -1,28 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import { orgnr } from '../brukerApi/helpers';
 import { faker } from '@faker-js/faker';
-import {
-    hentKalenderavtalerResolver,
-    hentNotifikasjonerResolver,
-    hentSakByIdResolver,
-    hentSakerResolver,
-    sakstyperResolver,
-} from '../brukerApi/resolvers';
-import { alleSaker } from '../brukerApi/alleSaker';
-import { alleNotifikasjoner } from '../brukerApi/alleNotifikasjoner';
+import { brukerApiHandlers } from '../brukerApi/resolvers';
 import { Merkelapp } from '../brukerApi/alleMerkelapper';
-import { alleKalenderavtaler } from '../brukerApi/alleKalenderavtaler';
 
 const nærmesteLederMerkelapper = [Merkelapp.Dialogmøte, Merkelapp.Oppfølging];
-const nærmesteLederSaker = alleSaker.filter(({ merkelapp }) =>
-    nærmesteLederMerkelapper.includes(merkelapp as Merkelapp)
-);
-const nærmesteLederNotifikasjoner = alleNotifikasjoner.filter(({ merkelapp }) =>
-    nærmesteLederMerkelapper.includes(merkelapp as Merkelapp)
-);
-const nærmesteLederKalenderavtaler = alleKalenderavtaler.filter(({ merkelapp }) =>
-    nærmesteLederMerkelapper.includes(merkelapp as Merkelapp)
-);
 
 const underenheter = [
     {
@@ -67,9 +49,7 @@ export const nærmesteLederScenario = [
     }),
 
     // brukerApi
-    hentSakerResolver(nærmesteLederSaker),
-    sakstyperResolver(nærmesteLederSaker.map(({ merkelapp }) => merkelapp as Merkelapp)),
-    hentNotifikasjonerResolver(nærmesteLederNotifikasjoner),
-    hentKalenderavtalerResolver(nærmesteLederKalenderavtaler),
-    hentSakByIdResolver(nærmesteLederSaker),
+    ...brukerApiHandlers([nærmesteLederOrganisasjon], (merkelapp) =>
+        nærmesteLederMerkelapper.includes(merkelapp)
+    ),
 ];

--- a/src/mocks/scenarios/regnskapsforerScenario.ts
+++ b/src/mocks/scenarios/regnskapsforerScenario.ts
@@ -2,17 +2,9 @@ import { http, HttpResponse } from 'msw';
 import { faker } from '@faker-js/faker';
 import { orgnr } from '../brukerApi/helpers';
 import { fromEntries } from '../../utils/Record';
-import { alleSaker } from '../brukerApi/alleSaker';
 import { Merkelapp } from '../brukerApi/alleMerkelapper';
-import {
-    hentKalenderavtalerResolver,
-    hentNotifikasjonerResolver,
-    hentSakByIdResolver,
-    hentSakerResolver,
-    sakstyperResolver,
-} from '../brukerApi/resolvers';
-import { alleKalenderavtaler } from '../brukerApi/alleKalenderavtaler';
-import { alleNotifikasjoner } from '../brukerApi/alleNotifikasjoner';
+import { brukerApiHandlers } from '../brukerApi/resolvers';
+import { nærmesteLederOrganisasjon } from './nærmesteLederScenario';
 
 const tilganger = [
     '4936:1', // inntektsmelding
@@ -66,21 +58,10 @@ const regnskapsførerSakstyper = [
     //Merkelapp.Yrkesskade,
 ];
 
-const regnskapsførerSaker = alleSaker.filter(({ merkelapp }) =>
-    regnskapsførerSakstyper.includes(merkelapp as Merkelapp)
-);
-const regnskapsførerKalenderavtaler = alleKalenderavtaler.filter(({ merkelapp }) =>
-    regnskapsførerSakstyper.includes(merkelapp as Merkelapp)
-);
-const regnskapsførerNotifikasjoner = alleNotifikasjoner.filter(({ merkelapp }) =>
-    regnskapsførerSakstyper.includes(merkelapp as Merkelapp)
-);
 export const regnskapsforerScenario = [
     regnskapsforerUserInfoScenario,
 
-    hentSakerResolver(regnskapsførerSaker),
-    sakstyperResolver(regnskapsførerSaker.map(({ merkelapp }) => merkelapp as Merkelapp)),
-    hentKalenderavtalerResolver(regnskapsførerKalenderavtaler),
-    hentNotifikasjonerResolver(regnskapsførerNotifikasjoner),
-    hentSakByIdResolver(regnskapsførerSaker),
+    ...brukerApiHandlers([nærmesteLederOrganisasjon], (merkelapp) =>
+        regnskapsførerSakstyper.includes(merkelapp)
+    ),
 ];


### PR DESCRIPTION
Endringer er som følger:
* Endrer demodata til å være litt mer sammenhengende.
* Innfrører en felles funksjon for å registrere brukerApiResolvers.
  * Denne funksjonen tar et organisasjonstre og et merkelapp filter
  * Virksomheter i orgtre blir kopiert til sakene randomly
  * Hvilke data som vises blir kalkulert basert på merkelapp filteret.

Viderefører at "alleSaker" er master data. På denne måten kan man endre demodata ett sted.