### PR TITLE
endre visning når antall sykmeldte er 0

### DIFF
--- a/src/Pages/Hovedside/Tjenestebokser/Sykmeldte/Sykmeldte.tsx
+++ b/src/Pages/Hovedside/Tjenestebokser/Sykmeldte/Sykmeldte.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { syfoURL } from '../../../../lenker';
 import syfoikon from './sykmeldte-ikon-kontrast.svg';
 import { StortTall, Tjenesteboks } from '../Tjenesteboks';
-import './Sykemeldte.css'
+import './Sykemeldte.css';
 
 import { useOrganisasjonsDetaljerContext } from '../../../OrganisasjonsDetaljerContext';
 
@@ -14,19 +14,23 @@ const Sykmeldte = () => {
             ikon={syfoikon}
             href={`${syfoURL}?bedrift=${valgtOrganisasjon.organisasjon.orgnr}`}
             tittel="Sykmeldte"
-            aria-label={`Sykemeldte, ${antallSykmeldte} ${antallSykmeldte === 1 ? 'sykmeldt' : 'sykmeldte'}. Se sykmeldte du har ansvar for å følge opp`}
+            aria-label={`Sykemeldte, du har ${antallSykmeldte} ${antallSykmeldte === 1 ? 'sykmeldt' : 'sykmeldte'} å følge opp`}
         >
-            <div>
-                {antallSykmeldte == 0 ? null : (
-                    <>
-                        <StortTall>{antallSykmeldte}</StortTall>{' '}
-                        {antallSykmeldte === 1 ? 'sykmeldt' : 'sykmeldte'}
-                    </>
-                )}
-                <div className="sykemeldteboks_bunntekst">
-                    Se sykmeldte du har ansvar for å følge opp
+            {antallSykmeldte === 0 ? (
+                <div>
+                    <div className="sykemeldteboks_bunntekst">
+                        Du har ingen sykmeldte å følge opp
+                    </div>
                 </div>
-            </div>
+            ) : (
+                <div>
+                    <StortTall>{antallSykmeldte}</StortTall>{' '}
+                    {antallSykmeldte === 1 ? 'sykmeldt' : 'sykmeldte'}
+                    <div className="sykemeldteboks_bunntekst">
+                        Se sykmeldte du har ansvar for å følge opp
+                    </div>
+                </div>
+            )}
         </Tjenesteboks>
     );
 };


### PR DESCRIPTION
se også:
* https://github.com/navikt/min-side-arbeidsgiver-api/pull/403

Når nærmeste leder ikke har noen sykmeldte så vil det vises slik:
![image](https://github.com/user-attachments/assets/b1d13acc-691f-4511-9b37-48f86788818a)

Ellers vises som før:
![image](https://github.com/user-attachments/assets/70a88b72-06eb-4b8e-8611-041eac97b7fd)
