### PR TITLE
Fjern kall til `selectArbeidsgiver` i pam-stillingsregistrering-api

### DIFF
--- a/src/Pages/Hovedside/Tjenestebokser/Arbeidsplassen/Arbeidsplassen.tsx
+++ b/src/Pages/Hovedside/Tjenestebokser/Arbeidsplassen/Arbeidsplassen.tsx
@@ -81,10 +81,6 @@ const useAntallannonser = () => {
 };
 
 const fetcher = async ({ url, orgnr }: { url: string; orgnr: string }) => {
-    await fetch(`${__BASE_PATH__}/stillingsregistrering-api/api/arbeidsgiver/${orgnr}`, {
-        method: 'POST',
-    });
-
     const respons = await fetch(url, {
         method: 'GET',
         headers: {

--- a/src/mocks/scenarios/dagligLederScenario.ts
+++ b/src/mocks/scenarios/dagligLederScenario.ts
@@ -107,9 +107,6 @@ export const dagligLederScenario = [
     }),
 
     // stillingsregistrering / pam / arbeidsplassen
-    http.post('/min-side-arbeidsgiver/stillingsregistrering-api/api/arbeidsgiver/:id', () =>
-        HttpResponse.json()
-    ),
     http.get('/min-side-arbeidsgiver/stillingsregistrering-api/api/stillinger/numberByStatus', () =>
         HttpResponse.json({
             TIL_GODKJENNING: faker.number.int({ min: 0, max: 20 }),

--- a/src/tests/A11y.test.tsx
+++ b/src/tests/A11y.test.tsx
@@ -16,10 +16,12 @@ import { orgnr } from '../mocks/brukerApi/helpers';
 import { faker } from '@faker-js/faker';
 import {
     hentKalenderavtalerResolver,
-    hentNotifikasjonerResolver, hentNotifikasjonerSistLest,
+    hentNotifikasjonerResolver,
+    hentNotifikasjonerSistLest,
     hentSakByIdResolver,
     hentSakerResolver,
-    sakstyperResolver, setNotifikasjonerSistLest,
+    sakstyperResolver,
+    setNotifikasjonerSistLest,
 } from '../mocks/brukerApi/resolvers';
 import { alleSaker } from '../mocks/brukerApi/alleSaker';
 import { Merkelapp } from '../mocks/brukerApi/alleMerkelapper';
@@ -255,9 +257,6 @@ const server = setupServer(
     ),
     http.get(`${__BASE_PATH__}/stillingsregistrering-api/api/stillinger/numberByStatus`, () =>
         HttpResponse.json({ PUBLISERT: 20 })
-    ),
-    http.post(`${__BASE_PATH__}/stillingsregistrering-api/api/arbeidsgiver/:orgnr`, () =>
-        HttpResponse.json({})
     ),
     http.get(/.*tiltaksgjennomforing-api\/avtaler.*/, () =>
         HttpResponse.json([


### PR DESCRIPTION
Bakgrunn for denne endringen er at vi ser en del 403 responser på dette kallet i prod. Dette skjer typisk dersom innlogget bruker har tilgangen "rekruttering" i en virksomhet og velger den i min-side-arbeidsgiver mens pam-stillingsregistrering-api tolker det som at brukeren ikke har tilgang til virksomheten. Dette kan f.eks skje ved at virksomheten er av organisasjonstype FLI (som kan ha ansatte) Dette resulterer i en http 403 respons som vi anser som en uforventet respons og det trigges en alert som i dette tilfellet er støy.

Grunnen til at vi kaller `selectArbeidsgiver` stammer fra gammel av hvor pam-stillingsregistrerting hadde session state for valgt virksomhet. Så for at bruker skulle få riktig virksomhet forhåndsvalgt når de navigerte til arbeidsplassen.no så satte man dette i et API kall. Denne session staten ble fjernet for en god stund siden: https://github.com/navikt/pam-stillingsregistrering-api/commit/09b609d2272f25fd336fd3f4bd1a0d5c5d273285#diff-e13f92ea526caad1dd7f07712434ace3c102169160bbef5e16a62fc6245d0b1a Som betyr at vi ikke trenger å gjøre dette API kallet lenger.