### PR TITLE
Legg til støtte for saker produsert på hovedenhet på saksoversikten

### DIFF
--- a/src/Pages/Saksoversikt/FilterChips.tsx
+++ b/src/Pages/Saksoversikt/FilterChips.tsx
@@ -27,7 +27,7 @@ export const FilterChips = () => {
             virksomheter: Set(),
             sortering: saksoversiktState.filter.sortering,
             sakstyper: [],
-            oppgaveFilter: []
+            oppgaveFilter: [],
         });
         logAnalyticsChipClick('tøm-alle-filtre', 'tøm-falle-filtre');
     };
@@ -117,17 +117,7 @@ export const FilterChips = () => {
                 navn={virksomhet.navn}
                 erHovedenhet={virksomhet.erHovedenhet}
                 onLukk={() => {
-                    let valgte = saksoversiktState.filter.virksomheter.remove(virksomhet.orgnr);
-
-                    // om virksomhet.OrganizatonNumber er siste underenhet, fjern hovedenhet også.
-                    const parent = orgnrTilParentMap.get(virksomhet.orgnr);
-                    if (parent === undefined) {
-                        return;
-                    }
-                    const underenheter = orgnrTilChildrenMap.get(parent) ?? [];
-                    if (underenheter.every((it) => !valgte.has(it))) {
-                        valgte = valgte.remove(parent);
-                    }
+                    const valgte = saksoversiktState.filter.virksomheter.remove(virksomhet.orgnr);
                     handleValgteVirksomheter(valgte);
                     logAnalyticsChipClick(
                         'organisasjon',

--- a/src/Pages/Saksoversikt/Saksfilter/Virksomhetsmeny/Virksomhetsmeny.tsx
+++ b/src/Pages/Saksoversikt/Saksfilter/Virksomhetsmeny/Virksomhetsmeny.tsx
@@ -101,7 +101,7 @@ export const Virksomhetsmeny = () => {
     };
 
     const onCheckboxGroupChange = (checkedEnheter: string[]) => {
-        const valgteVirksomheter = Set<string>(checkedEnheter); //utledNyeValgte(Set<string>(checkedEnheter));
+        const valgteVirksomheter = utledNyeValgte(Set<string>(checkedEnheter));
         setFilter({ ...filter, virksomheter: valgteVirksomheter });
         logAnalyticsValgteVirksomheter(valgteVirksomheter);
     };

--- a/src/Pages/Saksoversikt/Saksfilter/Virksomhetsmeny/Virksomhetsmeny.tsx
+++ b/src/Pages/Saksoversikt/Saksfilter/Virksomhetsmeny/Virksomhetsmeny.tsx
@@ -101,7 +101,7 @@ export const Virksomhetsmeny = () => {
     };
 
     const onCheckboxGroupChange = (checkedEnheter: string[]) => {
-        const valgteVirksomheter = utledNyeValgte(Set<string>(checkedEnheter));
+        const valgteVirksomheter = Set<string>(checkedEnheter); //utledNyeValgte(Set<string>(checkedEnheter));
         setFilter({ ...filter, virksomheter: valgteVirksomheter });
         logAnalyticsValgteVirksomheter(valgteVirksomheter);
     };

--- a/src/Pages/Saksoversikt/useSaker.test.ts
+++ b/src/Pages/Saksoversikt/useSaker.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest';
+import { beregnVirksomhetsnummer } from './useSaker';
+import Immutable from 'immutable';
+
+test('beregnVirksomhetsnummer fungerer som forventet', () => {
+    const tre = [
+        {
+            orgnr: '1',
+            navn: '1',
+            organisasjonsform: 'AS',
+            underenheter: [
+                { orgnr: '1.2', navn: '1.2', organisasjonsform: 'BEDR', underenheter: [] },
+            ],
+        },
+        {
+            orgnr: '1.1',
+            navn: '1.1',
+            organisasjonsform: 'ORGL',
+            underenheter: [
+                { orgnr: '1.1.1', navn: '1.1.1', organisasjonsform: 'BEDR', underenheter: [] },
+            ],
+        },
+        {
+            orgnr: '1.3.1',
+            navn: '1.3.1',
+            organisasjonsform: 'ORGL',
+            underenheter: [
+                { orgnr: '1.3.1.1', navn: '1.3.1.1', organisasjonsform: 'BEDR', underenheter: [] },
+                { orgnr: '1.3.1.2', navn: '1.3.1.2', organisasjonsform: 'BEDR', underenheter: [] },
+            ],
+        },
+    ];
+
+    expect(beregnVirksomhetsnummer(tre, Immutable.Set([]))).toEqual([
+        '1.2',
+        '1.1.1',
+        '1.3.1.1',
+        '1.3.1.2',
+    ]);
+    expect(beregnVirksomhetsnummer(tre, Immutable.Set(['1.3.1']))).toEqual([
+        '1.3.1',
+        '1.3.1.1',
+        '1.3.1.2',
+    ]);
+    expect(beregnVirksomhetsnummer(tre, Immutable.Set(['1.3.1', '1.3.1.1']))).toEqual([
+        '1.3.1',
+        '1.3.1.1',
+    ]);
+});

--- a/src/Pages/Saksoversikt/useSaker.test.ts
+++ b/src/Pages/Saksoversikt/useSaker.test.ts
@@ -32,8 +32,11 @@ test('beregnVirksomhetsnummer fungerer som forventet', () => {
     ];
 
     expect(beregnVirksomhetsnummer(tre, Immutable.Set([]))).toEqual([
+        '1',
         '1.2',
+        '1.1',
         '1.1.1',
+        '1.3.1',
         '1.3.1.1',
         '1.3.1.2',
     ]);

--- a/src/Pages/Saksoversikt/useSaker.ts
+++ b/src/Pages/Saksoversikt/useSaker.ts
@@ -117,9 +117,10 @@ export const beregnVirksomhetsnummer = (
     virksomheter: Set<string>
 ): string[] => {
     if (virksomheter.size === 0) {
-        return flatUtTre(organisasjonstre).flatMap(({ underenheter }) =>
-            underenheter.map((it) => it.orgnr)
-        );
+        return flatUtTre(organisasjonstre).flatMap((organisasjon) => [
+            organisasjon.orgnr,
+            ...organisasjon.underenheter.map((it) => it.orgnr),
+        ]);
     }
 
     return flatUtTre(organisasjonstre).flatMap((organisasjon) => {

--- a/src/Pages/Saksoversikt/useSaker.ts
+++ b/src/Pages/Saksoversikt/useSaker.ts
@@ -112,7 +112,7 @@ const HENT_SAKER: TypedDocumentNode<SakerResultat> = gql`
  * internal = { H, U1 }
  * external = { H, U1 }
  */
-const beregnVirksomhetsnummer = (
+export const beregnVirksomhetsnummer = (
     organisasjonstre: Organisasjon[],
     virksomheter: Set<string>
 ): string[] => {
@@ -126,10 +126,11 @@ const beregnVirksomhetsnummer = (
         if (virksomheter.has(organisasjon.orgnr)) {
             const underenheterOrgnr = organisasjon.underenheter.map((it) => it.orgnr);
             const valgteUnderenheter = underenheterOrgnr.filter((it) => virksomheter.has(it));
+
             if (valgteUnderenheter.length === 0) {
-                return underenheterOrgnr;
+                return [organisasjon.orgnr, ...underenheterOrgnr];
             } else {
-                return valgteUnderenheter;
+                return [organisasjon.orgnr, ...valgteUnderenheter];
             }
         } else {
             return [];


### PR DESCRIPTION
Siste saker støtter dette ut av boksen da den bruker hentNotifikasjoner Query, som går på tvers av alle virksomheter, også hovedenheter.

På saksoversikt trengs det oppdateres slik at hovedenhet sendes med i query hentSaker.
Det er også endret litt på oppførsel i checkboksene. Slik at hovedenhet ikke fjernes automatisk dersom siste underenhet fjernes. Dette fordi det nå kan komme saker på hovedenhet. 