### PR TITLE
oppdater tiltaksgjennomforing-api til ny ingress

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -47,14 +47,14 @@ spec:
       external:
         - host: arbeidsgiver-gcp.dev.nav.no
         - host: arbeidsgiver.intern.dev.nav.no
-        - host: tiltak-proxy.dev-fss-pub.nais.io
+        - host: tiltaksgjennomforing-api.intern.dev.nav.no
         - host: aareg-innsyn-arbeidsgiver-api.dev-fss-pub.nais.io
         - host: arbeidsplassen.intern.dev.nav.no
         - host: storage.googleapis.com
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltak-proxy
+        - application: tiltaksgjennomforing-api
           namespace: arbeidsgiver
           cluster: dev-fss
         - application: aareg-innsyn-arbeidsgiver-api

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -54,7 +54,9 @@ spec:
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-
+        - application: tiltaksgjennomforing-api
+          namespace: arbeidsgiver
+          cluster: dev-fss
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
           cluster: dev-fss

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -54,9 +54,7 @@ spec:
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltaksgjennomforing-api
-          namespace: arbeidsgiver
-          cluster: dev-fss
+
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
           cluster: dev-fss

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -47,7 +47,7 @@ spec:
       external:
         - host: arbeidsgiver-gcp.dev.nav.no
         - host: arbeidsgiver.intern.dev.nav.no
-        - host: tiltaksgjennomforing-api.intern.dev.nav.no
+        - host: tiltaksgjennomforing-api.dev-fss-pub.nais.io
         - host: aareg-innsyn-arbeidsgiver-api.dev-fss-pub.nais.io
         - host: arbeidsplassen.intern.dev.nav.no
         - host: storage.googleapis.com

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -52,9 +52,7 @@ spec:
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltaksgjennomforing-api
-          namespace: arbeidsgiver
-          cluster: prod-fss
+
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
           cluster: prod-fss

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -45,14 +45,14 @@ spec:
     outbound:
       external:
         - host: arbeidsgiver.nav.no
-        - host: tiltak-proxy.prod-fss-pub.nais.io
+        - host: tiltaksgjennomforing-api.intern.nav.no
         - host: aareg-innsyn-arbeidsgiver-api.prod-fss-pub.nais.io
         - host: arbeidsplassen.nav.no
         - host: storage.googleapis.com
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-        - application: tiltak-proxy
+        - application: tiltaksgjennomforing-api
           namespace: arbeidsgiver
           cluster: prod-fss
         - application: aareg-innsyn-arbeidsgiver-api

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -52,7 +52,9 @@ spec:
       rules:
         - application: min-side-arbeidsgiver-api
         - application: notifikasjon-bruker-api
-
+        - application: tiltaksgjennomforing-api
+          namespace: arbeidsgiver
+          cluster: prod-fss
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
           cluster: prod-fss

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -45,7 +45,7 @@ spec:
     outbound:
       external:
         - host: arbeidsgiver.nav.no
-        - host: tiltaksgjennomforing-api.intern.nav.no
+        - host: tiltaksgjennomforing-api.prod-fss-pub.nais.io
         - host: aareg-innsyn-arbeidsgiver-api.prod-fss-pub.nais.io
         - host: arbeidsplassen.nav.no
         - host: storage.googleapis.com

--- a/server/server.js
+++ b/server/server.js
@@ -226,8 +226,8 @@ const main = async () => {
                     }),
                 },
                 target: {
-                    dev: 'https://tiltaksgjennomforing-api.intern.dev.nav.no/tiltaksgjennomforing-api',
-                    prod: 'https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api',
+                    dev: 'https://tiltaksgjennomforing-api.dev-fss-pub.nais.io/tiltaksgjennomforing-api',
+                    prod: 'https://tiltaksgjennomforing-api.prod-fss-pub.nais.io/tiltaksgjennomforing-api',
                 }[MILJO],
             })
         );

--- a/server/server.js
+++ b/server/server.js
@@ -195,8 +195,8 @@ const main = async () => {
             tokenXMiddleware({
                 log: log,
                 audience: {
-                    dev: 'dev-fss:arbeidsgiver:tiltak-proxy',
-                    prod: 'prod-fss:arbeidsgiver:tiltak-proxy',
+                    dev: 'dev-fss:arbeidsgiver:tiltaksgjennomforing-api',
+                    prod: 'prod-fss:arbeidsgiver:tiltaksgjennomforing-api',
                 }[MILJO],
             }),
             createProxyMiddleware({
@@ -226,8 +226,8 @@ const main = async () => {
                     }),
                 },
                 target: {
-                    dev: 'https://tiltak-proxy.dev-fss-pub.nais.io/tiltaksgjennomforing-api',
-                    prod: 'https://tiltak-proxy.prod-fss-pub.nais.io/tiltaksgjennomforing-api',
+                    dev: 'https://tiltaksgjennomforing-api.intern.dev.nav.no/tiltaksgjennomforing-api',
+                    prod: 'https://tiltaksgjennomforing-api.intern.nav.no/tiltaksgjennomforing-api',
                 }[MILJO],
             })
         );


### PR DESCRIPTION
Bytter fra tiltak-proxy (FSS pub) til direkte kall mot tiltaksgjennomforing-api på ny (FSS pub) ingress.